### PR TITLE
change ー to _

### DIFF
--- a/_example/advanced_bot/bot.go
+++ b/_example/advanced_bot/bot.go
@@ -53,7 +53,7 @@ func (bot *Bot) Say(
 
 // GuildInfo demonstrates the use of command flags, in this case the GuildOnly
 // flag.
-func (bot *Bot) GーGuildInfo(m *gateway.MessageCreateEvent) (string, error) {
+func (bot *Bot) G_GuildInfo(m *gateway.MessageCreateEvent) (string, error) {
 	g, err := bot.Ctx.Guild(m.GuildID)
 	if err != nil {
 		return "", fmt.Errorf("Failed to get guild: %v", err)

--- a/_example/advanced_bot/debug.go
+++ b/_example/advanced_bot/debug.go
@@ -44,19 +44,19 @@ func (d *Debug) Goroutines(m *gateway.MessageCreateEvent) (string, error) {
 }
 
 // ~go GOOS
-func (d *Debug) RーGOOS(m *gateway.MessageCreateEvent) (string, error) {
+func (d *Debug) R_GOOS(m *gateway.MessageCreateEvent) (string, error) {
 	return strings.Title(runtime.GOOS), nil
 }
 
 // ~go GC
-func (d *Debug) RーGC(m *gateway.MessageCreateEvent) (string, error) {
+func (d *Debug) R_GC(m *gateway.MessageCreateEvent) (string, error) {
 	runtime.GC()
 	return "Done.", nil
 }
 
 // ~go die
 // This command will be hidden from ~help by default.
-func (d *Debug) AーDie(m *gateway.MessageCreateEvent) error {
+func (d *Debug) A_Die(m *gateway.MessageCreateEvent) error {
 	log.Fatalln("User", m.Author.Username, "killed the bot x_x")
 	return nil
 }

--- a/bot/ctx_plumb_test.go
+++ b/bot/ctx_plumb_test.go
@@ -21,7 +21,7 @@ func (h *hasPlumb) Normal(_ *gateway.MessageCreateEvent) error {
 	return nil
 }
 
-func (h *hasPlumb) PーPlumber(
+func (h *hasPlumb) P_Plumber(
 	_ *gateway.MessageCreateEvent, c Content) error {
 
 	h.Plumbed = string(c)

--- a/bot/ctx_test.go
+++ b/bot/ctx_test.go
@@ -21,7 +21,7 @@ type testCommands struct {
 	Typed   bool
 }
 
-func (t *testCommands) MーBumpCounter(interface{}) error {
+func (t *testCommands) M_BumpCounter(interface{}) error {
 	t.Counter++
 	return nil
 }

--- a/bot/nameflag.go
+++ b/bot/nameflag.go
@@ -4,7 +4,7 @@ import "strings"
 
 type NameFlag uint64
 
-const FlagSeparator = 'ー'
+const FlagSeparator = '_'
 
 const None NameFlag = 0
 
@@ -62,7 +62,7 @@ const Hidden NameFlag = 1 << 5
 // if the main struct manually handles command switching. This example
 // demonstrates the second use-case:
 //
-//    func (s *Sub) PーMain(
+//    func (s *Sub) P_Main(
 //        c *gateway.MessageCreateGateway, c *Content) error {
 //
 //        // Input:  !sub this is a command

--- a/bot/nameflag_test.go
+++ b/bot/nameflag_test.go
@@ -12,10 +12,10 @@ func TestNameFlag(t *testing.T) {
 	}
 
 	var entries = []entry{{
-		Name:   "AーEcho",
+		Name:   "A_Echo",
 		Expect: AdminOnly,
 	}, {
-		Name:   "RAーGC",
+		Name:   "RA_GC",
 		Expect: Raw | AdminOnly,
 	}}
 


### PR DESCRIPTION
I currently cannot easily type `ー` on my keyboard. This hinders development using this library, and I'm sure it does for others.

Hopefully `_` is an acceptable alternative.