### PR TITLE
Add PublicFlags to User

### DIFF
--- a/discord/user.go
+++ b/discord/user.go
@@ -23,8 +23,9 @@ type User struct {
 	Locale string `json:"locale,omitempty"`
 	Email  string `json:"email,omitempty"`
 
-	Flags UserFlags `json:"flags,omitempty"`
-	Nitro UserNitro `json:"premium_type,omitempty"`
+	Flags       UserFlags `json:"flags,omitempty"`
+	PublicFlags UserFlags `json:"public_flags,omitempty"`
+	Nitro       UserNitro `json:"premium_type,omitempty"`
 }
 
 func (u User) Mention() string {


### PR DESCRIPTION
In the Discord API, User objects were recently given a [public_flags](https://github.com/discord/discord-api-docs/commit/3787619e821291ab5882130ed4b0413da905cf30) property that bots can access (without OAuth). I've added a field to the User struct for this.