### PR TITLE
State: fix State.Message not working when the message's channel is not found in the Store

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -437,9 +437,9 @@ func (s *State) Message(channelID, messageID discord.Snowflake) (*discord.Messag
 	if cerr != nil {
 		wg.Add(1)
 		go func() {
-			c, err = s.Session.Channel(channelID)
+			c, cerr = s.Session.Channel(channelID)
 			if err == nil {
-				err = s.Store.ChannelSet(c)
+				cerr = s.Store.ChannelSet(c)
 			}
 
 			wg.Done()

--- a/state/state.go
+++ b/state/state.go
@@ -438,7 +438,7 @@ func (s *State) Message(channelID, messageID discord.Snowflake) (*discord.Messag
 		wg.Add(1)
 		go func() {
 			c, cerr = s.Session.Channel(channelID)
-			if err == nil {
+			if cerr == nil {
 				cerr = s.Store.ChannelSet(c)
 			}
 


### PR DESCRIPTION
This PR adds a fix for `State.Message`, that prevents said method from failing, if the message's channel is not found in the `Store`.