### PR TITLE
Add user_id to SpeakingData

### DIFF
--- a/voice/voicegateway/commands.go
+++ b/voice/voicegateway/commands.go
@@ -105,7 +105,7 @@ const (
 )
 
 // OPCode 5
-// https://discordapp.com/developers/docs/topics/voice-connections#speaking-example-speaking-payload
+// https://discord.com/developers/docs/topics/voice-connections#speaking-example-speaking-payload
 type SpeakingData struct {
 	Speaking SpeakingFlag   `json:"speaking"`
 	Delay    int            `json:"delay"`

--- a/voice/voicegateway/commands.go
+++ b/voice/voicegateway/commands.go
@@ -105,11 +105,12 @@ const (
 )
 
 // OPCode 5
-// https://discord.com/developers/docs/topics/voice-connections#speaking-example-speaking-payload
+// https://discordapp.com/developers/docs/topics/voice-connections#speaking-example-speaking-payload
 type SpeakingData struct {
-	Speaking SpeakingFlag `json:"speaking"`
-	Delay    int          `json:"delay"`
-	SSRC     uint32       `json:"ssrc"`
+	Speaking SpeakingFlag   `json:"speaking"`
+	Delay    int            `json:"delay"`
+	SSRC     uint32         `json:"ssrc"`
+	UserID   discord.UserID `json:"user_id,omitempty"`
 }
 
 // Speaking sends a Speaking operation (opcode 5) to the Gateway Gateway.


### PR DESCRIPTION
Undocumented field, discordgo uses it. Likely used to map speaking states in the client to user ids.