### PR TITLE
Add support for voice gateway events

### DIFF
--- a/internal/handleloop/handleloop.go
+++ b/internal/handleloop/handleloop.go
@@ -1,0 +1,60 @@
+// Package handleloop provides clean abstractions to handle listening to
+// channels and passing them onto event handlers.
+package handleloop
+
+import "github.com/diamondburned/arikawa/v2/utils/handler"
+
+// Loop provides a reusable event looper abstraction. It is thread-safe to use
+// concurrently.
+type Loop struct {
+	dst  *handler.Handler
+	run  chan struct{}
+	stop chan struct{}
+}
+
+func NewLoop(dst *handler.Handler) *Loop {
+	return &Loop{
+		dst:  dst,
+		run:  make(chan struct{}, 1), // intentional 1 buffer
+		stop: make(chan struct{}),    // intentional unbuffer
+	}
+}
+
+// Start starts a new event loop. It will try to stop existing loops before.
+func (l *Loop) Start(src <-chan interface{}) {
+	// Ensure we're stopped.
+	l.Stop()
+
+	// Mark that we're running.
+	l.run <- struct{}{}
+
+	go func() {
+		for {
+			select {
+			case event := <-src:
+				l.dst.Call(event)
+
+			case <-l.stop:
+				l.stop <- struct{}{}
+				return
+			}
+		}
+	}()
+}
+
+// Stop tries to stop the Loop. If the Loop is not running, then it does
+// nothing; thus, it can be called multiple times.
+func (l *Loop) Stop() {
+	// Ensure that we are running before stopping.
+	select {
+	case <-l.run:
+		// running
+	default:
+		return
+	}
+
+	// send a close request
+	l.stop <- struct{}{}
+	// wait for a reply
+	<-l.stop
+}

--- a/state/state.go
+++ b/state/state.go
@@ -62,7 +62,7 @@ type State struct {
 
 	// *: State doesn't actually keep track of pinned messages.
 
-	readyMu sync.Mutex
+	readyMu *sync.Mutex
 	ready   gateway.ReadyEvent
 
 	// StateLog logs all errors that come from the state cache. This includes
@@ -128,6 +128,7 @@ func NewFromSession(s *session.Session, store Store) (*State, error) {
 		Store:             store,
 		Handler:           handler.New(),
 		StateLog:          func(err error) {},
+		readyMu:           new(sync.Mutex),
 		fewMessages:       map[discord.ChannelID]struct{}{},
 		fewMutex:          new(sync.Mutex),
 		unavailableGuilds: moreatomic.NewGuildIDSet(),

--- a/voice/integration_test.go
+++ b/voice/integration_test.go
@@ -71,6 +71,11 @@ func TestIntegration(t *testing.T) {
 
 	finish("joining the voice channel")
 
+	// Add handler to receive speaking update
+	vs.AddHandler(func(e *voicegateway.SpeakingEvent) {
+		finish("received voice speaking event")
+	})
+
 	// Trigger speaking.
 	if err := vs.Speaking(voicegateway.Microphone); err != nil {
 		t.Fatal("Failed to start speaking:", err)

--- a/voice/voice.go
+++ b/voice/voice.go
@@ -131,14 +131,17 @@ func (v *Voice) GetSession(guildID discord.GuildID) (*Session, bool) {
 // RemoveSession removes a session.
 func (v *Voice) RemoveSession(guildID discord.GuildID) {
 	v.mapmutex.Lock()
-	defer v.mapmutex.Unlock()
-
-	// Ensure that the session is disconnected.
-	if ses, ok := v.sessions[guildID]; ok {
-		ses.Disconnect()
+	ses, ok := v.sessions[guildID]
+	if !ok {
+		v.mapmutex.Unlock()
+		return
 	}
 
 	delete(v.sessions, guildID)
+	v.mapmutex.Unlock()
+
+	// Ensure that the session is disconnected.
+	ses.Disconnect()
 }
 
 // JoinChannel joins the specified channel in the specified guild.

--- a/voice/voicegateway/commands.go
+++ b/voice/voicegateway/commands.go
@@ -107,9 +107,10 @@ const (
 // OPCode 5
 // https://discord.com/developers/docs/topics/voice-connections#speaking-example-speaking-payload
 type SpeakingData struct {
-	Speaking SpeakingFlag `json:"speaking"`
-	Delay    int          `json:"delay"`
-	SSRC     uint32       `json:"ssrc"`
+	Speaking SpeakingFlag   `json:"speaking"`
+	Delay    int            `json:"delay"`
+	SSRC     uint32         `json:"ssrc"`
+	UserID   discord.UserID `json:"user_id,omitempty"`
 }
 
 // Speaking sends a Speaking operation (opcode 5) to the Gateway Gateway.

--- a/voice/voicegateway/commands.go
+++ b/voice/voicegateway/commands.go
@@ -105,7 +105,7 @@ const (
 )
 
 // OPCode 5
-// https://discord.com/developers/docs/topics/voice-connections#speaking-example-speaking-payload
+// https://discordapp.com/developers/docs/topics/voice-connections#speaking-example-speaking-payload
 type SpeakingData struct {
 	Speaking SpeakingFlag   `json:"speaking"`
 	Delay    int            `json:"delay"`

--- a/voice/voicegateway/events.go
+++ b/voice/voicegateway/events.go
@@ -50,3 +50,18 @@ type HelloEvent struct {
 // OPCode 9
 // https://discord.com/developers/docs/topics/voice-connections#resuming-voice-connection-example-resumed-payload
 type ResumedEvent struct{}
+
+// OPCode 12
+// (undocumented)
+type ClientConnectEvent struct {
+	UserID    discord.UserID `json:"user_id"`
+	AudioSSRC uint32         `json:"audio_ssrc"`
+	VideoSSRC uint32         `json:"video_ssrc"`
+}
+
+// OPCode 13
+// Undocumented, existence mentioned in below issue
+// https://github.com/discord/discord-api-docs/issues/510
+type ClientDisconnectEvent struct {
+	UserID discord.UserID `json:"user_id"`
+}

--- a/voice/voicegateway/gateway.go
+++ b/voice/voicegateway/gateway.go
@@ -33,6 +33,8 @@ var (
 	ErrNoEndpoint  = errors.New("no endpoint was received")
 )
 
+type Event = interface{}
+
 // State contains state information of a voice gateway.
 type State struct {
 	GuildID   discord.GuildID
@@ -57,6 +59,7 @@ type Gateway struct {
 	reconnect moreatomic.Bool
 
 	EventLoop wsutil.PacemakerLoop
+	Events    chan Event
 
 	// ErrorLog will be called when an error occurs (defaults to log.Println)
 	ErrorLog func(err error)
@@ -77,6 +80,7 @@ func New(state State) *Gateway {
 		state:      state,
 		WS:         wsutil.New(endpoint),
 		Timeout:    wsutil.WSTimeout,
+		Events:     make(chan Event, wsutil.WSBuffer),
 		ErrorLog:   wsutil.WSError,
 		AfterClose: func(error) {},
 	}

--- a/voice/voicegateway/op.go
+++ b/voice/voicegateway/op.go
@@ -13,26 +13,30 @@ import (
 type OPCode = wsutil.OPCode
 
 const (
-	IdentifyOP           OPCode = 0 // send
-	SelectProtocolOP     OPCode = 1 // send
-	ReadyOP              OPCode = 2 // receive
-	HeartbeatOP          OPCode = 3 // send
-	SessionDescriptionOP OPCode = 4 // receive
-	SpeakingOP           OPCode = 5 // send/receive
-	HeartbeatAckOP       OPCode = 6 // receive
-	ResumeOP             OPCode = 7 // send
-	HelloOP              OPCode = 8 // receive
-	ResumedOP            OPCode = 9 // receive
-	// ClientDisconnectOP   OPCode = 13 // receive
+	IdentifyOP           OPCode = 0  // send
+	SelectProtocolOP     OPCode = 1  // send
+	ReadyOP              OPCode = 2  // receive
+	HeartbeatOP          OPCode = 3  // send
+	SessionDescriptionOP OPCode = 4  // receive
+	SpeakingOP           OPCode = 5  // send/receive
+	HeartbeatAckOP       OPCode = 6  // receive
+	ResumeOP             OPCode = 7  // send
+	HelloOP              OPCode = 8  // receive
+	ResumedOP            OPCode = 9  // receive
+	ClientConnectOP      OPCode = 12 // receive
+	ClientDisconnectOP   OPCode = 13 // receive
 )
 
 func (c *Gateway) HandleOP(op *wsutil.OP) error {
+	wsutil.WSDebug("Handle OP", op.Code)
 	switch op.Code {
 	// Gives information required to make a UDP connection
 	case ReadyOP:
 		if err := unmarshalMutex(op.Data, &c.ready, &c.mutex); err != nil {
 			return errors.Wrap(err, "failed to parse READY event")
 		}
+
+		c.Events <- &c.ready
 
 	// Gives information about the encryption mode and secret key for sending voice packets
 	case SessionDescriptionOP:
@@ -41,8 +45,13 @@ func (c *Gateway) HandleOP(op *wsutil.OP) error {
 
 	// Someone started or stopped speaking.
 	case SpeakingOP:
-		// ?
-		// TODO: handler in Session
+		ev := new(SpeakingEvent)
+
+		if err := json.Unmarshal(op.Data, ev); err != nil {
+			return errors.Wrap(err, "failed to parse Speaking event")
+		}
+
+		c.Events <- ev
 
 	// Heartbeat response from the server
 	case HeartbeatAckOP:
@@ -56,6 +65,24 @@ func (c *Gateway) HandleOP(op *wsutil.OP) error {
 	// Server is saying the connection was resumed, no data here.
 	case ResumedOP:
 		wsutil.WSDebug("Gateway connection has been resumed.")
+
+	case ClientConnectOP:
+		ev := new(ClientConnectEvent)
+
+		if err := json.Unmarshal(op.Data, ev); err != nil {
+			return errors.Wrap(err, "failed to parse Speaking event")
+		}
+
+		c.Events <- ev
+
+	case ClientDisconnectOP:
+		ev := new(ClientDisconnectEvent)
+
+		if err := json.Unmarshal(op.Data, ev); err != nil {
+			return errors.Wrap(err, "failed to parse Speaking event")
+		}
+
+		c.Events <- ev
 
 	default:
 		return fmt.Errorf("unknown OP code %d", op.Code)


### PR DESCRIPTION
This PR adds support for voice gateway events, including a couple undocumented/partially documented ones.

Now supported:

- Speaking update (Op 5)
- Client Connect (Op 12)
- Client Disconnect (Op 13)

Note: Bots do not receive all speaking events, only one per user in the time the user is in the channel. This appears to be intentional, and members in the Discord API server have confirmed it.