### PR TITLE
Add voice receive capability to v2

### DIFF
--- a/utils/wsutil/heart.go
+++ b/utils/wsutil/heart.go
@@ -92,6 +92,7 @@ func (p *PacemakerLoop) startLoop() error {
 			}
 
 		case ev, ok := <-p.events:
+			WSDebug("Handling event", string(ev.Data))
 			if !ok {
 				WSDebug("Events channel closed, stopping pacemaker.")
 				return nil

--- a/utils/wsutil/heart.go
+++ b/utils/wsutil/heart.go
@@ -92,7 +92,6 @@ func (p *PacemakerLoop) startLoop() error {
 			}
 
 		case ev, ok := <-p.events:
-			WSDebug("Handling event", string(ev.Data))
 			if !ok {
 				WSDebug("Events channel closed, stopping pacemaker.")
 				return nil

--- a/voice/session.go
+++ b/voice/session.go
@@ -339,3 +339,10 @@ func (s *Session) ensureClosed() {
 		s.gateway = nil
 	}
 }
+
+// ReadPacket reads a single packet from the UDP connection.
+// This is NOT at all thread safe, and must be used very carefully.
+// The backing buffer is always reused.
+func (s *Session) ReadPacket() (*udp.Packet, error) {
+	return s.voiceUDP.ReadPacket()
+}

--- a/voice/udp/udp.go
+++ b/voice/udp/udp.go
@@ -56,8 +56,8 @@ type Connection struct {
 
 	// recv fields
 	recvNonce  [24]byte
-	recvBuf    []byte  // len 1024
-	recvOpus   []byte  // len 1024 - packetHeaderSize - secretbox.Overhead
+	recvBuf    []byte  // len 1400
+	recvOpus   []byte  // len 1400
 	recvPacket *Packet // uses recvBuf's backing array
 }
 

--- a/voice/udp/udp.go
+++ b/voice/udp/udp.go
@@ -58,7 +58,7 @@ type Connection struct {
 	recvNonce  [24]byte
 	recvBuf    []byte  // len 1400
 	recvOpus   []byte  // len 1400
-	recvPacket *Packet // uses recvBuf's backing array
+	recvPacket *Packet // uses recvOpus' backing array
 }
 
 func DialConnectionCtx(ctx context.Context, addr string, ssrc uint32) (*Connection, error) {

--- a/voice/udp/udp.go
+++ b/voice/udp/udp.go
@@ -254,7 +254,7 @@ func (c *Connection) ReadPacket() (*Packet, error) {
 
 		var ok bool
 
-		c.recvPacket.Opus, ok = secretbox.Open(c.recvOpus, c.recvBuf[12:rlen], &c.recvNonce, &c.secret)
+		c.recvPacket.Opus, ok = secretbox.Open(c.recvOpus, c.recvBuf[packetHeaderSize:rlen], &c.recvNonce, &c.secret)
 
 		if !ok {
 			return nil, ErrDecryptionFailed

--- a/voice/voicegateway/commands.go
+++ b/voice/voicegateway/commands.go
@@ -105,7 +105,7 @@ const (
 )
 
 // OPCode 5
-// https://discordapp.com/developers/docs/topics/voice-connections#speaking-example-speaking-payload
+// https://discord.com/developers/docs/topics/voice-connections#speaking-example-speaking-payload
 type SpeakingData struct {
 	Speaking SpeakingFlag   `json:"speaking"`
 	Delay    int            `json:"delay"`


### PR DESCRIPTION
This adds a zero-allocation voice receive option - which is obviously not thread safe.

Some notes about the implementation vs what was discussed in Discord:

- Buffers are fixed to 1400, ideally voice data will NEVER be this big, and this ensures that there is never an issue. An extra few bytes isn't much.
- The for loop is retained on ReadPacket, as length 11 packets are seen as well at some points. This ensures we get a valid voice packet, instead of one without the expected data.