### PR TITLE
feat: handle iphone style quotes

### DIFF
--- a/bot/extras/shellwords/shellwords.go
+++ b/bot/extras/shellwords/shellwords.go
@@ -76,7 +76,7 @@ func Parse(line string) ([]string, error) {
 		}
 
 		switch r {
-		case '"':
+		case '"', '“', '”':
 			if !singleQuoted {
 				if doubleQuoted {
 					got = true
@@ -84,7 +84,7 @@ func Parse(line string) ([]string, error) {
 				doubleQuoted = !doubleQuoted
 				continue
 			}
-		case '\'', '`':
+		case '\'', '`', '‘', '’':
 			if !doubleQuoted {
 				if singleQuoted {
 					got = true

--- a/bot/extras/shellwords/shellwords_test.go
+++ b/bot/extras/shellwords/shellwords_test.go
@@ -58,6 +58,16 @@ func TestParse(t *testing.T) {
 			[]string{"this", "should", "not", "crash"},
 			true,
 		},
+		{
+			"iPhone “double quoted” text",
+			[]string{"iPhone", "double quoted", "text"},
+			true,
+		},
+		{
+			"iPhone ‘single quoted’ text",
+			[]string{"iPhone", "single quoted", "text"},
+			true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
As a user of the library, 
I want the iPhone curly quotes to be detected as argument delimiters,
so users typing commands on iPhones don't receive errors.

This happens because the iPhone by default uses the following quotes:
- `“Double”`
- `‘Single’`

Adding this as a PR because I believe this issue will affect all bots written from this library, so therefore should be fixed upstream for all users of the library.