### PR TITLE
Add automatic BotData connection into Gateway

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -58,10 +58,12 @@ type SessionStartLimit struct {
 func URL() (string, error) {
 	var g BotData
 
-	return g.URL, httputil.NewClient().RequestJSON(
-		&g, "GET",
-		EndpointGateway,
-	)
+	c := httputil.NewClient()
+	if err := c.RequestJSON(&g, "GET", EndpointGateway); err != nil {
+		return "", err
+	}
+
+	return g.URL, nil
 }
 
 // BotURL fetches the Gateway URL along with extra metadata. The token

--- a/gateway/integration_test.go
+++ b/gateway/integration_test.go
@@ -21,6 +21,21 @@ func init() {
 	}
 }
 
+func TestURL(t *testing.T) {
+	u, err := URL()
+	if err != nil {
+		t.Fatal("failed to get gateway URL:", err)
+	}
+
+	if u == "" {
+		t.Fatal("gateway URL is empty")
+	}
+
+	if !strings.HasPrefix(u, "wss://") {
+		t.Fatal("gatewayURL is invalid:", u)
+	}
+}
+
 func TestInvalidToken(t *testing.T) {
 	g, err := NewGateway("bad token")
 	if err != nil {


### PR DESCRIPTION
This pull request adds `gateway.BotData` usage into the gateway constructor to update the rate limiter. This is useful when the bot is being restarted. It also made new constructors to ease sharing `Identifier` instances around, which is necessary for sharding.

**Note** that there is currently no straightforward way to make bots use the new constructors. The intention is that most bots don't need sharding, and since bots that do need sharding need additional legwork to boot up multiple gateway instances that it would need more code anyway. Bots can thus borrow the new constructors to easily share a common` Identifier`.