### PR TITLE
Gateway: Handling of 'Sharding Required', Proper Closures and General Cleanup

### DIFF
--- a/api/message.go
+++ b/api/message.go
@@ -210,10 +210,10 @@ func (c *Client) SendText(channelID discord.ChannelID, content string) (*discord
 //
 // Fires a Message Create Gateway event.
 func (c *Client) SendTextReply(
-	channelID discord.ChannelID, 
-	content string, 
+	channelID discord.ChannelID,
+	content string,
 	referenceID discord.MessageID) (*discord.Message, error) {
-	
+
 	return c.SendMessageComplex(channelID, SendMessageData{
 		Content:   content,
 		Reference: &discord.MessageReference{MessageID: referenceID},
@@ -241,8 +241,8 @@ func (c *Client) SendEmbed(
 //
 // Fires a Message Create Gateway event.
 func (c *Client) SendEmbedReply(
-	channelID discord.ChannelID, 
-	e discord.Embed, 
+	channelID discord.ChannelID,
+	e discord.Embed,
 	referenceID discord.MessageID) (*discord.Message, error) {
 
 	return c.SendMessageComplex(channelID, SendMessageData{
@@ -277,7 +277,7 @@ func (c *Client) SendMessageReply(
 	content string,
 	embed *discord.Embed,
 	referenceID discord.MessageID) (*discord.Message, error) {
-	
+
 	return c.SendMessageComplex(channelID, SendMessageData{
 		Content:   content,
 		Embed:     embed,

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -194,10 +194,29 @@ func (g *Gateway) HasIntents(intents Intents) bool {
 
 // Close closes the underlying Websocket connection.
 func (g *Gateway) Close() error {
+	return g.close(false)
+}
+
+// CloseGracefully attempts to close the gateway connection gracefully, by
+// sending a closing frame before ending the connection. This will cause the
+// gateway's session id to be rendered invalid.
+//
+// Note that a graceful closure is only possible, if the wsutil.Connection of
+// the Gateway's Websocket implements wsutil.GracefulCloser.
+func (g *Gateway) CloseGracefully() error {
+	return g.close(true)
+}
+
+func (g *Gateway) close(graceful bool) (err error) {
 	wsutil.WSDebug("Trying to close. Pacemaker check skipped.")
 	wsutil.WSDebug("Closing the Websocket...")
 
-	err := g.WS.Close()
+	if graceful {
+		err = g.WS.CloseGracefully()
+	} else {
+		err = g.WS.Close()
+	}
+
 	if errors.Is(err, wsutil.ErrWebsocketClosed) {
 		wsutil.WSDebug("Websocket already closed.")
 		return nil
@@ -215,25 +234,6 @@ func (g *Gateway) Close() error {
 
 	g.AfterClose(err)
 	wsutil.WSDebug("AfterClose callback finished.")
-
-	return err
-}
-
-// CloseGracefully attempts to close the gateway connection gracefully, by
-// sending a closing frame before ending the connection. This will cause the
-// gateway's session id to be rendered invalid.
-//
-// Note that a graceful closure is only possible, if the wsutil.Connection of
-// the Gateway's Websocket implements wsutil.GracefulCloser.
-func (g *Gateway) CloseGracefully() error {
-	err := g.WS.CloseGracefully()
-	if errors.Is(err, wsutil.ErrWebsocketClosed) {
-		wsutil.WSDebug("Websocket already closed.")
-		return nil
-	}
-
-	// Stop the pacemaker loop; This shouldn't error, so return is ignored
-	g.WS.Close()
 
 	return err
 }

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -129,8 +129,11 @@ type Gateway struct {
 	// Defaults to noop.
 	FatalErrorCallback func(err error)
 
-	// OnScalingRequired is the function called, if discord closes with error
-	// code 4011 aka Scaling Required.
+	// OnScalingRequired is the function called, if Discord closes with error
+	// code 4011 aka Scaling Required. At the point of calling, the Gateway
+	// will be closed, and can, after increasing the number of shards, be
+	// reopened using Open. Reconnect or ReconnectCtx, however, will not be
+	// available as the session is invalidated.
 	OnScalingRequired func()
 
 	// AfterClose is called after each close or pause. It is used mainly for

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -417,9 +417,9 @@ func (g *Gateway) start(ctx context.Context) error {
 		g.waitGroup.Done() // mark so Close() can exit.
 		wsutil.WSDebug("Event loop stopped with error:", err)
 
-		// If Discord signals us sharding is required, do attempt to reconnect.
-		// Instead invalidate our session id, as we cannot resume, call
-		// OnShardingRequired, and exit.
+		// If Discord signals us sharding is required, do not attempt to
+		// reconnect. Instead invalidate our session id, as we cannot resume,
+		// call OnShardingRequired, and exit.
 		var cerr *websocket.CloseError
 		if errors.As(err, &cerr) && cerr != nil && cerr.Code == errCodeShardingRequired {
 			g.ErrorLog(cerr)

--- a/gateway/integration_test.go
+++ b/gateway/integration_test.go
@@ -88,7 +88,7 @@ func TestIntegration(t *testing.T) {
 			t.Fatal("Unexpected error while reconnecting:", err)
 		}
 
-		gateway.reconnectCtx(ctx)
+		gateway.ReconnectCtx(ctx)
 	})
 
 	g.ErrorLog = func(err error) { log.Println(err) }

--- a/gateway/integration_test.go
+++ b/gateway/integration_test.go
@@ -84,10 +84,14 @@ func TestIntegration(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 		defer cancel()
 
-		if err := gateway.ReconnectCtx(ctx); err != nil {
+		g.ErrorLog = func(err error) {
 			t.Fatal("Unexpected error while reconnecting:", err)
 		}
+
+		gateway.reconnectCtx(ctx)
 	})
+
+	g.ErrorLog = func(err error) { log.Println(err) }
 
 	// Wait for the desired event:
 	gotimeout(t, func() {

--- a/gateway/op.go
+++ b/gateway/op.go
@@ -51,11 +51,11 @@ func (g *Gateway) HandleOP(op *wsutil.OP) error {
 		}
 
 	case ReconnectOP:
-		// Server requests to reconnect, die and retry.
+		// Server requests to Reconnect, die and retry.
 		wsutil.WSDebug("ReconnectOP received.")
 
 		// Exit with the ReconnectOP error to force the heartbeat event loop to
-		// reconnect synchronously. Not really a fatal error.
+		// Reconnect synchronously. Not really a fatal error.
 		return wsutil.ErrBrokenConnection(ErrReconnectRequest)
 
 	case InvalidSessionOP:
@@ -67,7 +67,7 @@ func (g *Gateway) HandleOP(op *wsutil.OP) error {
 
 		// Invalid session, try and Identify.
 		if err := g.IdentifyCtx(ctx); err != nil {
-			// Can't identify, reconnect.
+			// Can't identify, Reconnect.
 			return wsutil.ErrBrokenConnection(ErrReconnectRequest)
 		}
 

--- a/utils/wsutil/ws.go
+++ b/utils/wsutil/ws.go
@@ -184,8 +184,7 @@ func (ws *Websocket) close(graceful bool) error {
 			return gc.CloseGracefully()
 		}
 
-		WSDebug("Conn: The Websocket's Connection does not support graceful closure. Closing normally instead.")
-		return ws.conn.Close()
+		WSDebug("Conn: The Websocket's Connection does not support graceful closure.")
 	}
 
 	WSDebug("Conn: Closing")

--- a/utils/wsutil/ws.go
+++ b/utils/wsutil/ws.go
@@ -157,29 +157,20 @@ func (ws *Websocket) SendCtx(ctx context.Context, b []byte) error {
 // Close closes the websocket connection. It assumes that the Websocket is
 // closed even when it returns an error. If the Websocket was already closed
 // before, ErrWebsocketClosed will be returned.
-func (ws *Websocket) Close() error {
+func (ws *Websocket) Close() error { return ws.close(false) }
+
+func (ws *Websocket) CloseGracefully() error { return ws.close(true) }
+
+// close closes the Websocket without acquiring the mutex. Refer to Close for
+// more information.
+func (ws *Websocket) close(graceful bool) error {
 	WSDebug("Conn: Acquiring mutex lock to close...")
 
 	ws.mutex.Lock()
 	defer ws.mutex.Unlock()
 
 	WSDebug("Conn: Write mutex acquired")
-	return ws.close(false)
-}
 
-func (ws *Websocket) CloseGracefully() error {
-	WSDebug("Conn: Acquiring mutex lock to close gracefully...")
-
-	ws.mutex.Lock()
-	defer ws.mutex.Unlock()
-
-	WSDebug("Conn: Write mutex acquired")
-	return ws.close(true)
-}
-
-// close closes the Websocket without acquiring the mutex. Refer to Close for
-// more information.
-func (ws *Websocket) close(graceful bool) error {
 	if ws.closed {
 		WSDebug("Conn: Websocket is already closed.")
 		return ErrWebsocketClosed


### PR DESCRIPTION
### Sharding
This PR adds support for handling the `4011` aka "Sharding Required" close code, to allow using `Gateway` for sharding. Handling is provided through a `OnShardingRequired` function inside the `Gateway` struct, called if Discord closes a connection with a `4011` error code. Additionally, the Gateway now won't continue to attempt to reconnect, but instead exit.

### `Gateway.Close`
`Gateway.Close` was adapted to behave like `.CloseGracefully` in an effort to ensure, that a user made call to `.Close` will end the WS connection, even if `Gateway` is in the process of reconnecting. Consequently, `.CloseGracefully` has been deprecated, and it has been advised to use `.Close` instead. Furthermore, `.Reconnect` and `.ReconnectCtx` were unexported, as user-triggered reconnections are now impossible.

### Other Improvements
* When attempting to reconnect, `Gateway.reconnectCtx` will now wait for an increasing delay between each attempt to connect, with a max delay of 60 seconds.
* `Gateway.ReconnectTimeout` was deprecated in favor of the new `Gateway.ReconnectAttempts`, to have more control over retries despite delays between tries