### PR TITLE
gateway: fix Joined field in GuildCreateEvent

### DIFF
--- a/gateway/events.go
+++ b/gateway/events.go
@@ -50,7 +50,7 @@ type (
 	GuildCreateEvent struct {
 		discord.Guild
 
-		Joined      discord.Timestamp `json:"timestamp,omitempty"`
+		Joined      discord.Timestamp `json:"joined_at,omitempty"`
 		Large       bool              `json:"large,omitempty"`
 		Unavailable bool              `json:"unavailable,omitempty"`
 		MemberCount uint64            `json:"member_count,omitempty"`


### PR DESCRIPTION
The Joined field in gateway.GuildCreateEvent has the wrong JSON tag and won't get filled (https://discord.com/developers/docs/resources/guild#guild-object), this fixes that.