### PR TITLE
discord: Add certified moderator user flag

### DIFF
--- a/discord/user.go
+++ b/discord/user.go
@@ -82,6 +82,7 @@ const (
 	_
 	VerifiedBot
 	VerifiedBotDeveloper
+	CertifiedModerator
 )
 
 type UserNitro uint8


### PR DESCRIPTION
A new user flag has been documented in discord/discord-api-docs@55cd3d7.
This commit adds the flag to arikawa.