### PR TITLE
API/Discord: Add RTCRegionID and VoiceQuality

### DIFF
--- a/api/channel.go
+++ b/api/channel.go
@@ -59,8 +59,18 @@ type CreateChannelData struct {
 	CategoryID discord.ChannelID `json:"parent_id,string,omitempty"`
 	// NSFW specifies whether the channel is nsfw.
 	//
-	// Channel Types: Text, News, Store.
+	// Channel Types: Text, News, Store
 	NSFW bool `json:"nsfw,omitempty"`
+	// RTCRegionID is the channel voice region id. It will be determined
+	// automatically set, if omitted.
+	//
+	// Channel Types: Voice
+	RTCRegionID string `json:"rtc_region,omitempty"`
+	// VideoQualityMode is the camera video quality mode of the voice channel.
+	// This defaults to discord.AutoVideoQuality, if not set.
+	//
+	// ChannelTypes: Voice
+	VoiceQualityMode discord.VideoQualityMode `json:"voice_quality_mode,omitempty"`
 }
 
 // CreateChannel creates a new channel object for the guild.


### PR DESCRIPTION
Discord added the above fields to `discord.Channel` and `api.ModifyChannelData`, without mentioning it in the Change Log. I'm not sure when they were added, so only targeting v3 for now.