### PR TITLE
api: client.RespondInteraction: don't unmarshal into unused variable

### DIFF
--- a/api/interaction.go
+++ b/api/interaction.go
@@ -44,8 +44,7 @@ type InteractionResponseData struct {
 func (c *Client) RespondInteraction(
 	id discord.InteractionID, token string, resp InteractionResponse) error {
 	var URL = EndpointInteractions + id.String() + "/" + token + "/callback"
-	var msg *discord.Message
-	return sendpart.POST(c.Client, resp, &msg, URL)
+	return sendpart.POST(c.Client, resp, nil, URL)
 }
 
 // NeedsMultipart returns true if the InteractionResponse has files.


### PR DESCRIPTION
When I was basing the function off of SendMessageComplex I forgot that the function RespondInteraction doesn't return a message.