### PR TITLE
Add IsPending to Member & Fix SupplementalMember json variable name

### DIFF
--- a/discord/guild.go
+++ b/discord/guild.go
@@ -338,6 +338,9 @@ type Member struct {
 	Deaf bool `json:"deaf"`
 	// Mute specifies whether the user is muted in voice channels.
 	Mute bool `json:"mute"`
+
+	// IsPending specifies whether the user has not yet passed the guild's Membership Screening requirements
+	IsPending bool `json:"pending"`
 }
 
 // Mention returns the mention of the role.

--- a/gateway/ready.go
+++ b/gateway/ready.go
@@ -196,7 +196,7 @@ type (
 		RoleIDs []discord.RoleID `json:"roles"`
 
 		GuildID     discord.GuildID `json:"guild_id,omitempty"`
-		IsPending   bool            `json:"is_pending,omitempty"`
+		IsPending   bool            `json:"pending,omitempty"`
 		HoistedRole discord.RoleID  `json:"hoisted_role"`
 
 		Mute bool `json:"mute"`
@@ -243,6 +243,7 @@ func ConvertSupplementalMember(sm SupplementalMember) discord.Member {
 		BoostedSince: sm.BoostedSince,
 		Deaf:         sm.Deaf,
 		Mute:         sm.Mute,
+		IsPending:    sm.IsPending,
 	}
 }
 


### PR DESCRIPTION
SupplementalMember was using the `is_pending` json variable while discord sends it as `pending` ([ref](https://discord.com/developers/docs/topics/gateway#guild-member-update-guild-member-update-event-fields))

This PR also adds the field in the SupplementalMember -> Member convertion method