### PR TITLE
support graceful shutdowns in Docker with SIGTERM

### DIFF
--- a/bot/ctx.go
+++ b/bot/ctx.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/pkg/errors"
@@ -224,7 +225,7 @@ func Run(token string, cmd interface{}, opts func(*Context) error) {
 // Wait blocks until SIGINT.
 func Wait() {
 	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, os.Interrupt)
+	signal.Notify(sigs, os.Interrupt, syscall.SIGTERM)
 	<-sigs
 }
 


### PR DESCRIPTION
Closes #229 

Allows for graceful shutdowns in Docker by listening for SIGTERM sent by [docker stop](https://docs.docker.com/engine/reference/commandline/stop/)

Only works if we are the main process in the container.