### PR TITLE
Fix #238 branch for region/voice server changes

### DIFF
--- a/voice/udp/connection.go
+++ b/voice/udp/connection.go
@@ -258,10 +258,8 @@ func (c *Connection) ReadPacket() (*Packet, error) {
 	}
 
 	for {
-		wsutil.WSDebug("reading from UDP connection:", c.conn.LocalAddr(), "->", c.conn.RemoteAddr())
 		i, err := c.conn.Read(c.recvBuffer)
 		if err != nil {
-			wsutil.WSDebug("error reading from UDP connection:", err)
 			return nil, err
 		}
 


### PR DESCRIPTION
I tested that this works, region changes are handled gracefully with packets from `ReadPacket` resuming like nothing happened.