### PR TITLE
v3: voice: udp.Manager for seamless reconnection

### DIFF
--- a/api/channel.go
+++ b/api/channel.go
@@ -175,6 +175,11 @@ type ModifyChannelData struct {
 	//
 	// Channel Types: Voice
 	VoiceUserLimit option.NullableUint `json:"user_limit,omitempty"`
+	// RTCRegionID is the channel voice region id. It will be determined
+	// automatically set, if omitted.
+	//
+	// Channel Types: Voice
+	RTCRegionID option.NullableString `json:"rtc_region,omitempty"`
 	// Overwrites are the channel or category-specific permissions.
 	//
 	// Channel Types: Text, News, Store, Voice, Category

--- a/utils/ws/conn.go
+++ b/utils/ws/conn.go
@@ -180,6 +180,10 @@ func (c *Conn) Send(ctx context.Context, b []byte) error {
 	conn := c.conn
 	c.mut.Unlock()
 
+	if conn == nil || conn.Conn == nil {
+		return ErrWebsocketClosed
+	}
+
 	select {
 	case conn.wrmut <- struct{}{}:
 		defer func() { <-conn.wrmut }()

--- a/utils/ws/gateway.go
+++ b/utils/ws/gateway.go
@@ -150,6 +150,8 @@ func (g *Gateway) Send(ctx context.Context, data Event) error {
 		Data: data,
 	}
 
+	WSDebug("sending command Op", op.Code, "type", op.Type)
+
 	b, err := json.Marshal(op)
 	if err != nil {
 		return errors.Wrap(err, "failed to encode payload")

--- a/utils/ws/ws.go
+++ b/utils/ws/ws.go
@@ -70,10 +70,9 @@ func (ws *Websocket) Dial(ctx context.Context) (<-chan Op, error) {
 // Send sends b over the Websocket with a deadline. It closes the internal
 // Websocket if the Send method errors out.
 func (ws *Websocket) Send(ctx context.Context, b []byte) error {
-	WSDebug("Acquiring the websoccket mutex for sending.")
+	WSDebug("Acquiring the websocket mutex for sending.")
 
 	ws.mutex.Lock()
-	WSDebug("Mutex lock acquired.")
 	sendLimiter := ws.sendLimiter
 	conn := ws.conn
 	ws.mutex.Unlock()
@@ -85,7 +84,7 @@ func (ws *Websocket) Send(ctx context.Context, b []byte) error {
 		return errors.Wrap(err, "SendLimiter failed")
 	}
 
-	WSDebug("Send has passed the rate limiting. Waiting on mutex.")
+	WSDebug("Send has passed the rate limiting.")
 
 	return conn.Send(ctx, b)
 }

--- a/voice/session_example_test.go
+++ b/voice/session_example_test.go
@@ -2,7 +2,6 @@ package voice_test
 
 import (
 	"context"
-	"io"
 	"log"
 	"testing"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/diamondburned/arikawa/v3/internal/testenv"
 	"github.com/diamondburned/arikawa/v3/state"
 	"github.com/diamondburned/arikawa/v3/voice"
+	"github.com/diamondburned/arikawa/v3/voice/testdata"
 )
 
 var (
@@ -24,9 +24,6 @@ func init() {
 		channelID = e.VoiceChID
 	}
 }
-
-// pseudo function for example
-func writeOpusInto(w io.Writer) {}
 
 // make godoc not show the full file
 func TestNoop(t *testing.T) {
@@ -54,8 +51,7 @@ func ExampleSession() {
 	}
 	defer v.Leave(context.TODO())
 
-	// Start writing Opus frames.
-	for {
-		writeOpusInto(v)
+	if err := testdata.WriteOpus(v, "testdata/nico.dca"); err != nil {
+		log.Fatalln("failed to write opus:", err)
 	}
 }

--- a/voice/testdata/testdata.go
+++ b/voice/testdata/testdata.go
@@ -1,0 +1,48 @@
+package testdata
+
+import (
+	"encoding/binary"
+	"io"
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+const Nico = "testdata/nico.dca"
+
+// WriteOpus reads the given file containing the Opus frames into the give
+// io.Writer.
+func WriteOpus(w io.Writer, file string) error {
+	f, err := os.Open(file)
+	if err != nil {
+		return errors.Wrap(err, "failed to open "+file)
+	}
+	defer f.Close()
+
+	var lenbuf [4]byte
+	for {
+		_, err := io.ReadFull(f, lenbuf[:])
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return errors.Wrap(err, "failed to read "+file)
+		}
+
+		// Read the integer
+		framelen := int64(binary.LittleEndian.Uint32(lenbuf[:]))
+
+		// Copy the frame.
+		_, err = io.CopyN(w, f, framelen)
+		if err != nil && err != io.EOF {
+			return errors.Wrap(err, "failed to write")
+		}
+	}
+}
+
+// WriterFunc wraps f to be an io.Writer.
+type WriterFunc func([]byte) (int, error)
+
+func (w WriterFunc) Write(b []byte) (int, error) {
+	return w(b)
+}

--- a/voice/udp/manager.go
+++ b/voice/udp/manager.go
@@ -1,0 +1,221 @@
+package udp
+
+import (
+	"context"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/diamondburned/arikawa/v3/utils/ws"
+	"github.com/pkg/errors"
+)
+
+// ErrManagerClosed is returned when a Manager that is already closed is dialed,
+// written to or read from.
+var ErrManagerClosed = errors.New("UDP connection manager is closed")
+
+// ErrDialWhileUnpaused is returned if Dial is called on the Manager without
+// pausing it first
+var ErrDialWhileUnpaused = errors.New("dial is called while manager is not paused")
+
+// Manager manages a UDP connection. It allows reconnecting. A Manager instance
+// is thread-safe, meaning it can be used concurrently.
+type Manager struct {
+	dialer *net.Dialer
+
+	stopMu   sync.Mutex
+	stopConn chan struct{}
+	stopDial context.CancelFunc
+
+	// conn state
+	conn     *Connection
+	connLock chan struct{}
+
+	frequency time.Duration
+	timeIncr  uint32
+}
+
+// NewManager creates a new UDP connection manager with the defalt dialer.
+func NewManager() *Manager {
+	return &Manager{
+		dialer:   &Dialer,
+		stopConn: make(chan struct{}),
+		connLock: make(chan struct{}, 1),
+	}
+}
+
+// SetDialer sets the manager's dialer. Calling this function while the Manager
+// is working will cause a panic. Only call this method directly after
+// construction.
+func (m *Manager) SetDialer(d *net.Dialer) {
+	select {
+	case m.connLock <- struct{}{}:
+		m.dialer = d
+		<-m.connLock
+	default:
+		panic("SetDialer called while Manager is working")
+	}
+}
+
+// Pause explicitly pauses the manager. It blocks until the Manager is paused or
+// the context expires.
+func (m *Manager) Pause(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case m.connLock <- struct{}{}:
+		return nil
+	}
+}
+
+// Close closes the current connection. If the connection is already closed,
+// then nothing is done and ErrManagerClosed is returned. Close does not pause
+// the connection; calls to Close while the user is using the connection will
+// result in the user getting ErrManagerClosed.
+func (m *Manager) Close() (err error) {
+	// Acquire the mutex first.
+	m.stopMu.Lock()
+	defer m.stopMu.Unlock()
+
+	// Cancel the dialing.
+	if m.stopDial != nil {
+		m.stopDial()
+		m.stopDial = nil
+	}
+
+	// Stop existing Manager users.
+	select {
+	case <-m.stopConn:
+		// m.stopConn already closed
+		ws.WSDebug("UDP manager already closed")
+		return ErrManagerClosed
+	default:
+		close(m.stopConn)
+		ws.WSDebug("UDP manager closed")
+	}
+
+	return nil
+}
+
+// IsClosed returns true if the connection is closed.
+func (m *Manager) IsClosed() bool {
+	return m.acquireConn() == nil
+}
+
+// Continue unpauses and resumes the active user. If the manager has been
+// successfully resumed, then true is returned, otherwise if it's already
+// continued, then false is returned.
+func (m *Manager) Continue() bool {
+	ws.WSDebug("UDP continued")
+
+	select {
+	case <-m.connLock:
+		return true
+	default:
+		return false
+	}
+}
+
+// Dial dials the internal connection to the given address and SSRC number. If
+// the Manager is not Paused, then an error is returned. The caller must call
+// Dial after Pause and before Unpause. If the Manager is already being dialed
+// elsewhere, then ErrAlreadyDialing is returned.
+func (m *Manager) Dial(ctx context.Context, addr string, ssrc uint32) (*Connection, error) {
+	select {
+	case m.connLock <- struct{}{}:
+		return nil, errors.New("Dial called on unpaused Manager")
+	default:
+		// ok
+	}
+
+	m.stopMu.Lock()
+	// Allow cancelling from another goroutine with this context.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	m.stopDial = cancel
+	m.stopMu.Unlock()
+
+	conn, err := DialConnectionCustom(ctx, m.dialer, addr, ssrc)
+	if err != nil {
+		// Unlock if we failed.
+		<-m.connLock
+		return nil, errors.Wrap(err, "failed to dial")
+	}
+
+	if m.frequency > 0 && m.timeIncr > 0 {
+		conn.ResetFrequency(m.frequency, m.timeIncr)
+	}
+
+	m.stopMu.Lock()
+	ws.WSDebug("setting UDP conn to one w/ gateway address", conn.GatewayIP)
+	m.conn = conn
+	m.stopDial = nil
+	m.stopConn = make(chan struct{})
+	m.stopMu.Unlock()
+
+	return conn, nil
+}
+
+// ResetFrequency sets the current connection and future connections' write
+// frequency. Note that calling this method while Connection is being used in a
+// different goroutine is not thread-safe.
+func (m *Manager) ResetFrequency(frameDuration time.Duration, timeIncr uint32) {
+	m.connLock <- struct{}{}
+	defer func() { <-m.connLock }()
+
+	m.frequency = frameDuration
+	m.timeIncr = timeIncr
+
+	if m.conn != nil {
+		m.conn.ResetFrequency(frameDuration, timeIncr)
+	}
+}
+
+// ReadPacket reads the current packet. It blocks until a packet arrives or
+// the Manager is closed.
+func (m *Manager) ReadPacket() (p *Packet, err error) {
+	conn := m.acquireConn()
+	if conn == nil {
+		return nil, ErrManagerClosed
+	}
+
+	return conn.ReadPacket()
+}
+
+// Write writes to the current connection in the manager. It blocks if the
+// connection is being re-established.
+func (m *Manager) Write(b []byte) (n int, err error) {
+	conn := m.acquireConn()
+	if conn == nil {
+		return 0, ErrManagerClosed
+	}
+
+	return conn.Write(b)
+}
+
+// acquireConn acquires the current connection and releases the lock, returning
+// the connection at that point in time. Nil is returned if Manager is closed.
+func (m *Manager) acquireConn() *Connection {
+	// Acquire the pause lock first. We must only rely on the stopConn being
+	// closed once we have this.
+	m.connLock <- struct{}{}
+	defer func() { <-m.connLock }()
+
+	m.stopMu.Lock()
+	defer m.stopMu.Unlock()
+
+	select {
+	case <-m.stopConn:
+		ws.WSDebug("UDP acquisition got stopped conn")
+		return nil
+	default:
+		// ok
+	}
+
+	if m.conn == nil {
+		ws.WSDebug("UDP acquisition got nil conn")
+	}
+
+	return m.conn
+}

--- a/voice/voice.go
+++ b/voice/voice.go
@@ -6,9 +6,11 @@ package voice
 
 import "github.com/diamondburned/arikawa/v3/gateway"
 
+// Intents are the intents needed for voice to work properly.
+const Intents = gateway.IntentGuilds | gateway.IntentGuildVoiceStates
+
 // AddIntents adds the needed voice intents into gw. Bots should always call
 // this before Open if voice is required.
 func AddIntents(gw interface{ AddIntents(gateway.Intents) }) {
-	gw.AddIntents(gateway.IntentGuilds)
-	gw.AddIntents(gateway.IntentGuildVoiceStates)
+	gw.AddIntents(Intents)
 }


### PR DESCRIPTION
This pull request breaks the previous v2 voice API to add in a `udp.Manager` that effectively manages reconnection of the voice UDP connection. This fixes a previous issue where changing the voice region would break the voice connection.

The biggest breaking change in this PR (as far as voice sending goes) actually has nothing to do with this fix. The change is written below:

```diff
 func (s *Session) JoinChannelCtx(
-	ctx context.Context, gID discord.GuildID, cID discord.ChannelID, mute, deaf bool) error {
+	ctx context.Context, chID discord.ChannelID, mute, deaf bool) error {
```

This change is made primarily for convenience.

A small side effect of this change is that the minimum supported Go version has been bumped to 1.16 for some reason. By the time v3 is finalized, however, Go 1.17 would've already been released, so this is fine.

This pull request fixes #238.