### PR TITLE
v3: discord: raise embed description limit to 4096 characters

### DIFF
--- a/discord/message_embed.go
+++ b/discord/message_embed.go
@@ -83,8 +83,8 @@ func (e *Embed) Validate() error {
 		return &OverboundError{len(e.Title), 256, "title"}
 	}
 
-	if len(e.Description) > 2048 {
-		return &OverboundError{len(e.Description), 2048, "description"}
+	if len(e.Description) > 4096 {
+		return &OverboundError{len(e.Description), 4096, "description"}
 	}
 
 	if len(e.Fields) > 25 {


### PR DESCRIPTION
Discord recently raised the character limit for embed descriptions to 4096 characters (https://discord.com/developers/docs/resources/channel#embed-limits), but this isn't reflected in embed.Validate() yet.