### PR TITLE
fix potential deadlock bug

### DIFF
--- a/utils/wsutil/ws.go
+++ b/utils/wsutil/ws.go
@@ -157,13 +157,7 @@ func (ws *Websocket) SendCtx(ctx context.Context, b []byte) error {
 // Close closes the websocket connection. It assumes that the Websocket is
 // closed even when it returns an error. If the Websocket was already closed
 // before, ErrWebsocketClosed will be returned.
-func (ws *Websocket) Close() error { return ws.close(false) }
-
-func (ws *Websocket) CloseGracefully() error { return ws.close(true) }
-
-// close closes the Websocket without acquiring the mutex. Refer to Close for
-// more information.
-func (ws *Websocket) close(graceful bool) error {
+func (ws *Websocket) Close() error {
 	WSDebug("Conn: Acquiring mutex lock to close...")
 
 	ws.mutex.Lock()
@@ -171,6 +165,23 @@ func (ws *Websocket) close(graceful bool) error {
 
 	WSDebug("Conn: Write mutex acquired")
 
+	return ws.close(false)
+}
+
+func (ws *Websocket) CloseGracefully() error {
+	WSDebug("Conn: Acquiring mutex lock to close...")
+
+	ws.mutex.Lock()
+	defer ws.mutex.Unlock()
+
+	WSDebug("Conn: Write mutex acquired")
+
+	return ws.close(true)
+}
+
+// close closes the Websocket without acquiring the mutex. Refer to Close for
+// more information.
+func (ws *Websocket) close(graceful bool) error {
 	if ws.closed {
 		WSDebug("Conn: Websocket is already closed.")
 		return ErrWebsocketClosed


### PR DESCRIPTION
(hopefully) fix an issue that has been causing freezing issues in production

I had initially mentioned this issue on discord ([here](https://discord.com/channels/118456055842734083/668491759827025940/860517100938199080]) for those who are in discord gophers) but as the issue remains i figured i'd just propose a fix

brief description of the issue:
when an error happens on trying to send a websocket message in `wsutil.(Websocket).SendCtx` and the error path tries to call `ws.close`, the current version ends up deadlocking because `SendCtx` has the mutex unlock deferred, and `close` currently tries to acquire a mutex lock
so the call to `close` then ends up stuck waiting for `SendCtx` to release its lock before it can do anything and `SendCtx` having called it normally is stuck waiting for `close` to finish before releasing its lock, thus meaning neither will continue and the mutex never gets unlocked and the websocket from then on is deadlocked
and as its just frozen and not crashed the system service manager won't restart it, and as other goroutines may still continue the go runtime also won't terminate it, leaving a bot that is just stuck until you terminate the process


the solution i have: having taken a closer look at the code i noticed that `close`'s comment states that it doesn't acquire a mutex lock (which in the current version is false because it does) and that there are only 3 cases of `close` being used
so, my solution is to just remove the mutex lock from `close` and copy it to `Close` and `CloseGracefully` instead, so the 2 public close functions work the same having the lock, while the call to `close` within `SendCtx` no longer runs into the deadlock because `close` itself no longer expects to acquire a lock