### PR TITLE
gateway+wsutil: Skip unknown events while reconnecting

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -474,7 +474,8 @@ func (g *Gateway) start(ctx context.Context) error {
 	// Expect either READY or RESUMED before continuing.
 	wsutil.WSDebug("Waiting for either READY or RESUMED.")
 
-	// WaitForEvent should
+	// WaitForEvent should until the bot becomes ready or resumes (if a
+	// previous ready event has already been called).
 	err := wsutil.WaitForEvent(ctx, g, ch, func(op *wsutil.OP) bool {
 		switch op.EventName {
 		case "READY":

--- a/gateway/op.go
+++ b/gateway/op.go
@@ -85,10 +85,10 @@ func (g *Gateway) HandleOP(op *wsutil.OP) error {
 		// Check if we know the event
 		fn, ok := EventCreator[op.EventName]
 		if !ok {
-			return fmt.Errorf(
-				"unknown event %s: %s",
-				op.EventName, string(op.Data),
-			)
+			return &wsutil.UnknownEventError{
+				Name: op.EventName,
+				Data: op.Data,
+			}
 		}
 
 		// Make a new pointer to the event


### PR DESCRIPTION
This change skips events that are unknown while the bot reconnects. This
is an event that is particularly rare as it requires unimplemented
events being called in the time before a bot's HELLO -> RESUME events
are called. This change explicitly returns unknown events as a special
time defined in wsutil/op.go and ignores them from reaching gateway/op.g