### PR TITLE
*: move Interaction to discord, update CommandCreateData

### DIFF
--- a/_example/buttons/main.go
+++ b/_example/buttons/main.go
@@ -30,16 +30,16 @@ func main() {
 	}
 
 	s.AddHandler(func(e *gateway.InteractionCreateEvent) {
-		if e.Type == gateway.CommandInteraction {
+		if e.Type == discord.CommandInteraction {
 			// Send a message with a button back on slash commands.
 			data := api.InteractionResponse{
 				Type: api.MessageInteractionWithSource,
 				Data: &api.InteractionResponseData{
 					Content: option.NewNullableString("This is a message with a button!"),
 					Components: &[]discord.Component{
-						discord.ActionRowComponent{
+						&discord.ActionRowComponent{
 							Components: []discord.Component{
-								discord.ButtonComponent{
+								&discord.ButtonComponent{
 									Label:    "Hello World!",
 									CustomID: "first_button",
 									Emoji: &discord.ButtonEmoji{
@@ -47,22 +47,22 @@ func main() {
 									},
 									Style: discord.PrimaryButton,
 								},
-								discord.ButtonComponent{
+								&discord.ButtonComponent{
 									Label:    "Secondary",
 									CustomID: "second_button",
 									Style:    discord.SecondaryButton,
 								},
-								discord.ButtonComponent{
+								&discord.ButtonComponent{
 									Label:    "Success",
 									CustomID: "success_button",
 									Style:    discord.SuccessButton,
 								},
-								discord.ButtonComponent{
+								&discord.ButtonComponent{
 									Label:    "Danger",
 									CustomID: "danger_button",
 									Style:    discord.DangerButton,
 								},
-								discord.ButtonComponent{
+								&discord.ButtonComponent{
 									Label: "Link",
 									URL:   "https://google.com",
 									Style: discord.LinkButton,
@@ -78,14 +78,14 @@ func main() {
 			}
 		}
 
-		if e.Type != gateway.ButtonInteraction {
+		if e.Type != discord.ComponentInteraction {
 			return
 		}
-
+		customID := e.Data.(*discord.ComponentInteractionData).CustomID
 		data := api.InteractionResponse{
 			Type: api.UpdateMessage,
 			Data: &api.InteractionResponseData{
-				Content: option.NewNullableString("Custom ID: " + e.Data.CustomID),
+				Content: option.NewNullableString("Custom ID: " + customID),
 			},
 		}
 

--- a/discord/application.go
+++ b/discord/application.go
@@ -13,6 +13,8 @@ import (
 type Command struct {
 	// ID is the unique id of the command.
 	ID CommandID `json:"id"`
+	// Type is the type of command.
+	Type CommandType `json:"type,omitempty"`
 	// AppID is the unique id of the parent application.
 	AppID AppID `json:"application_id"`
 	// GuildID is the guild id of the command, if not global.
@@ -26,33 +28,56 @@ type Command struct {
 	// Note that required options must be listed before optional options, and
 	// a command, or each individual subcommand, can have a maximum of 25
 	// options.
+	//
+	// It is only present on ChatInputCommands.
 	Options []CommandOption `json:"options,omitempty"`
 	// NoDefaultPermissions defines whether the command is NOT enabled by
 	// default when the app is added to a guild.
-	NoDefaultPermission bool `json:"default_permission"`
+	NoDefaultPermission bool `json:"-"`
 }
+
+type CommandType uint
+
+const (
+	ChatInputCommand CommandType = iota + 1
+	UserCommand
+	MessageCommand
+)
 
 func (c Command) MarshalJSON() ([]byte, error) {
 	type RawCommand Command
+	cmd := struct {
+		RawCommand
+		DefaultPermission bool `json:"default_permission"`
+	}{RawCommand: RawCommand(c)}
 
 	// Discord defaults default_permission to true, so we need to invert the
 	// meaning of the field (>No<DefaultPermission) to match Go's default
 	// value, false.
-	c.NoDefaultPermission = !c.NoDefaultPermission
+	cmd.DefaultPermission = !c.NoDefaultPermission
 
-	return json.Marshal((RawCommand)(c))
+	return json.Marshal(cmd)
 }
 
 func (c *Command) UnmarshalJSON(data []byte) error {
 	type RawCommand Command
-	if err := json.Unmarshal(data, (*RawCommand)(c)); err != nil {
+	cmd := struct {
+		*RawCommand
+		DefaultPermission bool `json:"default_permission"`
+	}{RawCommand: (*RawCommand)(c)}
+	if err := json.Unmarshal(data, &cmd); err != nil {
 		return err
 	}
 
 	// Discord defaults default_permission to true, so we need to invert the
 	// meaning of the field (>No<DefaultPermission) to match Go's default
 	// value, false.
-	c.NoDefaultPermission = !c.NoDefaultPermission
+	c.NoDefaultPermission = !cmd.DefaultPermission
+
+	// Discord defaults type to 1 if omitted.
+	if c.Type == 0 {
+		c.Type = ChatInputCommand
+	}
 
 	return nil
 }

--- a/discord/component.go
+++ b/discord/component.go
@@ -19,7 +19,8 @@ const (
 )
 
 // ComponentWrap wraps Component for the purpose of JSON unmarshalling.
-// Type assetions should be made on Component to access the underlying data.
+// Type assertions should be made on Component to access the underlying data.
+// The underlying types of the Component are pointer types.
 type ComponentWrap struct {
 	Component Component
 }
@@ -35,7 +36,7 @@ func UnwrapComponents(wraps []ComponentWrap) []Component {
 }
 
 // Type returns the underlying component's type.
-func (c ComponentWrap) Type() ComponentType {
+func (c *ComponentWrap) Type() ComponentType {
 	return c.Component.Type()
 }
 
@@ -79,7 +80,7 @@ type ActionRowComponent struct {
 }
 
 // Type implements the Component interface.
-func (ActionRowComponent) Type() ComponentType {
+func (*ActionRowComponent) Type() ComponentType {
 	return ActionRowComponentType
 }
 
@@ -150,7 +151,7 @@ type ButtonComponent struct {
 }
 
 // Type implements the Component interface.
-func (ButtonComponent) Type() ComponentType {
+func (*ButtonComponent) Type() ComponentType {
 	return ButtonComponentType
 }
 
@@ -215,7 +216,7 @@ type SelectComponentOption struct {
 }
 
 // Type implements the Component interface.
-func (SelectComponent) Type() ComponentType {
+func (*SelectComponent) Type() ComponentType {
 	return SelectComponentType
 }
 
@@ -240,6 +241,6 @@ type UnknownComponent struct {
 }
 
 // Type implements the Component interface.
-func (u UnknownComponent) Type() ComponentType {
+func (u *UnknownComponent) Type() ComponentType {
 	return u.typ
 }

--- a/discord/interaction.go
+++ b/discord/interaction.go
@@ -1,0 +1,138 @@
+package discord
+
+import (
+	"strconv"
+
+	"github.com/diamondburned/arikawa/v3/utils/json"
+)
+
+// https://discord.com/developers/docs/topics/gateway#interactions
+type Interaction struct {
+	ID        InteractionID   `json:"id"`
+	AppID     AppID           `json:"application_id"`
+	Type      InteractionType `json:"type"`
+	Data      InteractionData `json:"data,omitempty"`
+	ChannelID ChannelID       `json:"channel_id,omitempty"`
+	Token     string          `json:"token"`
+	Version   int             `json:"version"`
+
+	// Message is the message the component was attached to.
+	// Only present for component interactions, not command interactions.
+	Message *Message `json:"message,omitempty"`
+
+	// Member is only present if this came from a guild.
+	Member  *Member `json:"member,omitempty"`
+	GuildID GuildID `json:"guild_id,omitempty"`
+
+	// User is only present if this didn't come from a guild.
+	User *User `json:"user,omitempty"`
+}
+
+func (i *Interaction) UnmarshalJSON(p []byte) error {
+	type interaction Interaction
+	v := struct {
+		Data json.Raw `json:"data,omitempty"`
+		*interaction
+	}{interaction: (*interaction)(i)}
+	if err := json.Unmarshal(p, &v); err != nil {
+		return err
+	}
+
+	switch v.Type {
+	case PingInteraction:
+		return nil
+	case ComponentInteraction:
+		i.Data = &ComponentInteractionData{}
+	case CommandInteraction:
+		i.Data = &CommandInteractionData{}
+	default:
+		i.Data = &UnknownInteractionData{typ: v.Type}
+	}
+
+	return json.Unmarshal(v.Data, i.Data)
+}
+
+type InteractionType uint
+
+const (
+	PingInteraction InteractionType = iota + 1
+	CommandInteraction
+	ComponentInteraction
+)
+
+// InteractionData holds the data of an interaction.
+// Type assertions should be made on InteractionData to access the underlying data.
+// The underlying types of the InteractionData are pointer types.
+type InteractionData interface {
+	Type() InteractionType
+}
+
+type ComponentInteractionData struct {
+	CustomID      string        `json:"custom_id"`
+	ComponentType ComponentType `json:"component_type"`
+	Values        []string      `json:"values"`
+}
+
+func (*ComponentInteractionData) Type() InteractionType {
+	return ComponentInteraction
+}
+
+type CommandInteractionData struct {
+	ID      CommandID           `json:"id"`
+	Name    string              `json:"name"`
+	Options []InteractionOption `json:"options"`
+}
+
+func (*CommandInteractionData) Type() InteractionType {
+	return CommandInteraction
+}
+
+type UnknownInteractionData struct {
+	json.Raw
+	typ InteractionType
+}
+
+func (u *UnknownInteractionData) Type() InteractionType {
+	return u.typ
+}
+
+type InteractionOption struct {
+	Name    string              `json:"name"`
+	Value   json.Raw            `json:"value"`
+	Options []InteractionOption `json:"options"`
+}
+
+// String will return the value if the option's value is a valid string.
+// Otherwise, it will return the raw JSON value of the other type.
+func (o InteractionOption) String() string {
+	val := string(o.Value)
+	s, err := strconv.Unquote(val)
+	if err != nil {
+		return s
+	}
+	return val
+}
+
+func (o InteractionOption) Int() (int64, error) {
+	var i int64
+	err := o.Value.UnmarshalTo(&i)
+	return i, err
+}
+
+func (o InteractionOption) Bool() (bool, error) {
+	var b bool
+	err := o.Value.UnmarshalTo(&b)
+	return b, err
+}
+
+func (o InteractionOption) Snowflake() (Snowflake, error) {
+	var id Snowflake
+	err := o.Value.UnmarshalTo(&id)
+	return id, err
+}
+
+func (o InteractionOption) Float() (float64, error) {
+	var f float64
+	err := o.Value.UnmarshalTo(&f)
+	return f, err
+}

--- a/gateway/events.go
+++ b/gateway/events.go
@@ -1,10 +1,7 @@
 package gateway
 
 import (
-	"bytes"
-
 	"github.com/diamondburned/arikawa/v3/discord"
-	"github.com/diamondburned/arikawa/v3/utils/json"
 )
 
 // Rules: VOICE_STATE_UPDATE -> VoiceStateUpdateEvent
@@ -397,85 +394,8 @@ type (
 	}
 )
 
-// https://discord.com/developers/docs/topics/gateway#interactions
-type (
-	InteractionCreateEvent struct {
-		ID        discord.InteractionID `json:"id"`
-		AppID     discord.AppID         `json:"application_id"`
-		Type      InteractionType       `json:"type"`
-		Data      *InteractionData      `json:"data,omitempty"`
-		ChannelID discord.ChannelID     `json:"channel_id,omitempty"`
-		Token     string                `json:"token"`
-		Version   int                   `json:"version"`
-		Message   *discord.Message      `json:"message"`
-
-		// Member is only present if this came from a guild.
-		Member  *discord.Member `json:"member,omitempty"`
-		GuildID discord.GuildID `json:"guild_id,omitempty"`
-
-		// User is only present if this didn't come from a guild.
-		User *discord.User `json:"user,omitempty"`
-	}
-)
-
-type InteractionType uint
-
-const (
-	PingInteraction InteractionType = iota + 1
-	CommandInteraction
-	ButtonInteraction
-)
-
-// TODO: InteractionData is being overloaded by Slash Command and Button at the moment.
-//       Separate them when v3 rolls out.
-
-type InteractionData struct {
-	// Slash commands
-	ID      discord.CommandID   `json:"id"`
-	Name    string              `json:"name"`
-	Options []InteractionOption `json:"options"`
-
-	// Button and select
-	CustomID      string                `json:"custom_id"`
-	ComponentType discord.ComponentType `json:"component_type"`
-
-	// Select
-	Values []string `json:"values"`
-}
-
-type InteractionOption struct {
-	Name    string              `json:"name"`
-	Value   json.Raw            `json:"value"`
-	Options []InteractionOption `json:"options"`
-}
-
-func (o InteractionOption) String() string {
-	val := bytes.Trim([]byte(o.Value), `"`)
-	return string(val)
-}
-
-func (o InteractionOption) Int() (int64, error) {
-	var i int64
-	err := o.Value.UnmarshalTo(&i)
-	return i, err
-}
-
-func (o InteractionOption) Bool() (bool, error) {
-	var b bool
-	err := o.Value.UnmarshalTo(&b)
-	return b, err
-}
-
-func (o InteractionOption) Snowflake() (discord.Snowflake, error) {
-	var id discord.Snowflake
-	err := o.Value.UnmarshalTo(&id)
-	return id, err
-}
-
-func (o InteractionOption) Float() (float64, error) {
-	var f float64
-	err := o.Value.UnmarshalTo(&f)
-	return f, err
+type InteractionCreateEvent struct {
+	discord.Interaction
 }
 
 // Undocumented


### PR DESCRIPTION
- Moved gateway.InteractionCreateData to discord.Interaction, now
gateway.InteractionCreateData is a struct that wraps
discord.Interaction.
- Split InteractionData into CommandInteractionData and
ComponentInteractionData.
- Renamed ButtonInteraction to ComponentInteraction.
- Updated api.CommandCreateData to add new fields.