### PR TITLE
gateway: make IdentifyData's intents field an optional.Uint

### DIFF
--- a/bot/extras/middlewares/middlewares_test.go
+++ b/bot/extras/middlewares/middlewares_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/diamondburned/arikawa/v3/session"
 	"github.com/diamondburned/arikawa/v3/state"
 	"github.com/diamondburned/arikawa/v3/state/store"
+	"github.com/diamondburned/arikawa/v3/utils/json/option"
 )
 
 func TestAdminOnly(t *testing.T) {
@@ -19,7 +20,7 @@ func TestAdminOnly(t *testing.T) {
 				Gateway: &gateway.Gateway{
 					Identifier: &gateway.Identifier{
 						IdentifyData: gateway.IdentifyData{
-							Intents: gateway.IntentGuilds | gateway.IntentGuildMembers,
+							Intents: option.NewUint(uint(gateway.IntentGuilds | gateway.IntentGuildMembers)),
 						},
 					},
 				},
@@ -65,7 +66,7 @@ func TestGuildOnly(t *testing.T) {
 				Gateway: &gateway.Gateway{
 					Identifier: &gateway.Identifier{
 						IdentifyData: gateway.IdentifyData{
-							Intents: gateway.IntentGuilds,
+							Intents: option.NewUint(uint(gateway.IntentGuilds)),
 						},
 					},
 				},

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -17,6 +17,7 @@ import (
 	"github.com/diamondburned/arikawa/v3/api"
 	"github.com/diamondburned/arikawa/v3/internal/moreatomic"
 	"github.com/diamondburned/arikawa/v3/utils/json"
+	"github.com/diamondburned/arikawa/v3/utils/json/option"
 	"github.com/diamondburned/arikawa/v3/utils/wsutil"
 	"github.com/gorilla/websocket"
 	"github.com/pkg/errors"
@@ -197,7 +198,11 @@ func NewCustomIdentifiedGateway(gatewayURL string, id *Identifier) *Gateway {
 // AddIntents adds a Gateway Intent before connecting to the Gateway. As such,
 // this function will only work before Open() is called.
 func (g *Gateway) AddIntents(i Intents) {
-	g.Identifier.Intents |= i
+	if g.Identifier.Intents == nil {
+		g.Identifier.Intents = option.NewUint(uint(i))
+	} else {
+		*g.Identifier.Intents |= uint(i)
+	}
 }
 
 // HasIntents reports if the Gateway has the passed Intents.
@@ -205,11 +210,11 @@ func (g *Gateway) AddIntents(i Intents) {
 // If no intents are set, i.e. if using a user account HasIntents will always
 // return true.
 func (g *Gateway) HasIntents(intents Intents) bool {
-	if g.Identifier.Intents == 0 {
+	if g.Identifier.Intents == nil {
 		return true
 	}
 
-	return g.Identifier.Intents.Has(intents)
+	return Intents(*g.Identifier.Intents).Has(intents)
 }
 
 // Close closes the underlying Websocket connection, invalidating the session

--- a/gateway/identify.go
+++ b/gateway/identify.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/diamondburned/arikawa/v3/utils/json/option"
 	"github.com/pkg/errors"
 	"golang.org/x/time/rate"
 )
@@ -76,7 +77,15 @@ type IdentifyData struct {
 
 	Presence *UpdateStatusData `json:"presence,omitempty"`
 
-	Intents Intents `json:"intents,omitempty"`
+	// Intents specifies which groups of events the gateway
+	// connection will receive.
+	//
+	// For user accounts, it must be nil.
+	//
+	// For bot accounts, it must not be nil, and
+	// Gateway.AddIntents(0) can be used if you want to
+	// specify no intents.
+	Intents option.Uint `json:"intents"`
 }
 
 // DefaultIdentifyData creates a default IdentifyData with the given token.


### PR DESCRIPTION
<https://discord.com/developers/docs/topics/gateway#identify>
The `intents` field is required, and 0 is a valid value for intents. Currently if you try to connect with `intents` = 0, you get an error from Discord because the Identify would be sent without an `intents` field.