### PR TITLE
discord, gateway: update some things to match current API docs

### DIFF
--- a/discord/application.go
+++ b/discord/application.go
@@ -9,7 +9,7 @@ import (
 // Command is the base "command" model that belongs to an application. This is
 // what you are creating when you POST a new command.
 //
-// https://discord.com/developers/docs/interactions/slash-commands#application-command-object
+// https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-structure
 type Command struct {
 	// ID is the unique id of the command.
 	ID CommandID `json:"id"`
@@ -34,6 +34,9 @@ type Command struct {
 	// NoDefaultPermissions defines whether the command is NOT enabled by
 	// default when the app is added to a guild.
 	NoDefaultPermission bool `json:"-"`
+	// Version is an autoincrementing version identifier updated during
+	// substantial record changes
+	Version Snowflake `json:"version,omitempty"`
 }
 
 type CommandType uint

--- a/discord/message.go
+++ b/discord/message.go
@@ -147,13 +147,14 @@ const (
 	// name of the thread.
 	ThreadCreatedMessage
 	InlinedReplyMessage
-	ApplicationCommandMessage
+	ChatInputCommandMessage
 	// ThreadStarterMessage is a new message sent as the first message in
 	// threads that are started from an existing message in the parent channel.
 	// It only contains a message reference field that points to the message
 	// from which the thread was started.
 	ThreadStarterMessage
 	GuildInviteReminderMessage
+	ContextMenuCommand
 )
 
 type MessageFlags enum.Enum
@@ -371,6 +372,11 @@ type Attachment struct {
 	Height uint `json:"height,omitempty"`
 	// Width is the width of the file, if it is an image.
 	Width uint `json:"width,omitempty"`
+	// Ephemeral is whether this attachment is ephemeral. Ephemeral attachments
+	// will automatically be removed after a set period of time. Ephemeral
+	// attachments on messages are guaranteed to be available as long as
+	// the message itself exists.
+	Ephemeral bool `json:"ephemeral,omitempty"`
 }
 
 //

--- a/discord/permission.go
+++ b/discord/permission.go
@@ -78,11 +78,16 @@ const (
 	// threads
 	PermissionManageThreads
 	// Allows for creating and participating in threads.
-	PermissionUsePublicThreads
+	PermissionCreatePublicThreads
 	// Allows for creating and participating in private threads.
-	PermissionUsePrivateThreads
+	PermissionCreatePrivateThreads
 	// Allows the usage of custom stickers from other servers
 	PermissionUseExternalStickers
+	// Allows for sending messages in threads
+	PermissionSendMessagesInThreads
+	// Allows for launching activities (applications with the EMBEDDED flag)
+	// in a voice channel
+	PermissionStartEmbeddedActivities
 
 	PermissionAllText = 0 |
 		PermissionViewChannel |
@@ -95,9 +100,12 @@ const (
 		PermissionMentionEveryone |
 		PermissionUseExternalEmojis |
 		PermissionUseSlashCommands |
-		PermissionUsePublicThreads |
-		PermissionUsePrivateThreads |
-		PermissionUseExternalStickers
+		PermissionManageThreads |
+		PermissionCreatePublicThreads |
+		PermissionCreatePrivateThreads |
+		PermissionUseExternalStickers |
+		PermissionAddReactions |
+		PermissionSendMessagesInThreads
 
 	PermissionAllVoice = 0 |
 		PermissionViewChannel |
@@ -109,16 +117,15 @@ const (
 		PermissionMoveMembers |
 		PermissionUseVAD |
 		PermissionPrioritySpeaker |
-		PermissionRequestToSpeak
+		PermissionRequestToSpeak |
+		PermissionStartEmbeddedActivities
 
 	PermissionAllChannel = 0 |
 		PermissionAllText |
 		PermissionAllVoice |
 		PermissionCreateInstantInvite |
 		PermissionManageRoles |
-		PermissionManageChannels |
-		PermissionAddReactions |
-		PermissionViewAuditLog
+		PermissionManageChannels
 
 	PermissionAll = 0 |
 		PermissionAllChannel |
@@ -130,7 +137,7 @@ const (
 		PermissionManageEmojisAndStickers |
 		PermissionManageNicknames |
 		PermissionChangeNickname |
-		PermissionManageThreads
+		PermissionViewAuditLog
 )
 
 func (p Permissions) Has(perm Permissions) bool {

--- a/gateway/events.go
+++ b/gateway/events.go
@@ -420,10 +420,3 @@ type (
 		discord.Relationship
 	}
 )
-
-type (
-	ApplicationCommandUpdateEvent struct {
-		discord.Command
-		GuildID discord.GuildID `json:"guild_id"`
-	}
-)

--- a/gateway/events_map.go
+++ b/gateway/events_map.go
@@ -73,6 +73,4 @@ var EventCreator = map[string]func() Event{
 
 	"RELATIONSHIP_ADD":    func() Event { return new(RelationshipAddEvent) },
 	"RELATIONSHIP_REMOVE": func() Event { return new(RelationshipRemoveEvent) },
-
-	"APPLICATION_COMMAND_UPDATE": func() Event { return new(ApplicationCommandUpdateEvent) },
 }


### PR DESCRIPTION
Should I make Command.Version its own type like CommandVersion instead of Snowflake? 