### PR TITLE
v3: discord, api, gateway: add per-guild avatars

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -46,10 +46,10 @@ func (c *Client) ModifyMe(data ModifySelfData) (*discord.User, error) {
 	)
 }
 
-// ChangeOwnNickname modifies the nickname of the current user in a guild.
+// ModifyCurrentMember modifies the nickname of the current user in a guild.
 //
 // Fires a Guild Member Update Gateway event.
-func (c *Client) ChangeOwnNickname(
+func (c *Client) ModifyCurrentMember(
 	guildID discord.GuildID, nick string) error {
 
 	var param struct {
@@ -60,7 +60,7 @@ func (c *Client) ChangeOwnNickname(
 
 	return c.FastRequest(
 		"PATCH",
-		EndpointGuilds+guildID.String()+"/members/@me/nick",
+		EndpointGuilds+guildID.String()+"/members/@me",
 		httputil.WithJSONBody(param),
 	)
 }

--- a/api/user.go
+++ b/api/user.go
@@ -26,7 +26,7 @@ func (c *Client) Me() (*discord.User, error) {
 }
 
 // https://discord.com/developers/docs/resources/user#modify-current-user-json-params
-type ModifySelfData struct {
+type ModifyCurrentUserData struct {
 	// Username is the user's username, if changed may cause the user's
 	// discriminator to be randomized.
 	Username option.String `json:"username,omitempty"`
@@ -36,8 +36,8 @@ type ModifySelfData struct {
 	AuditLogReason `json:"-"`
 }
 
-// ModifyMe modifies the requester's user account settings.
-func (c *Client) ModifyMe(data ModifySelfData) (*discord.User, error) {
+// ModifyCurrentUser modifies the requester's user account settings.
+func (c *Client) ModifyCurrentUser(data ModifyCurrentUserData) (*discord.User, error) {
 	var u *discord.User
 	return u, c.RequestJSON(
 		&u,

--- a/discord/guild.go
+++ b/discord/guild.go
@@ -328,6 +328,8 @@ type Member struct {
 	Nick string `json:"nick,omitempty"`
 	// RoleIDs is an array of role object ids.
 	RoleIDs []RoleID `json:"roles"`
+	// Avatar is this member's guild avatar.
+	Avatar Hash `json:"avatar,omitempty"`
 
 	// Joined specifies when the user joined the guild.
 	Joined Timestamp `json:"joined_at"`
@@ -346,6 +348,24 @@ type Member struct {
 // Mention returns the mention of the role.
 func (m Member) Mention() string {
 	return "<@!" + m.User.ID.String() + ">"
+}
+
+// AvatarURL returns the URL of the Avatar Image. It automatically detects a
+// suitable type.
+func (m Member) AvatarURL(guild GuildID) string {
+	return m.AvatarURLWithType(AutoImage, guild)
+}
+
+// AvatarURLWithType returns the URL of the Avatar Image using the passed type.
+// If the member has no Avatar, an empty string will be returned.
+//
+// Supported Image Types: PNG, JPEG, WebP, GIF
+func (m Member) AvatarURLWithType(t ImageType, guild GuildID) string {
+	if m.Avatar == "" {
+		return ""
+	}
+
+	return "https://cdn.discordapp.com/guilds/" + guild.String() + "/users/" + m.User.ID.String() + "/avatars/" + t.format(m.Avatar)
 }
 
 // https://discord.com/developers/docs/resources/guild#ban-object

--- a/gateway/events.go
+++ b/gateway/events.go
@@ -166,6 +166,7 @@ type (
 		RoleIDs []discord.RoleID `json:"roles"`
 		User    discord.User     `json:"user"`
 		Nick    string           `json:"nick"`
+		Avatar  discord.Hash     `json:"avatar"`
 	}
 
 	// GuildMembersChunkEvent is sent when Guild Request Members is called.
@@ -247,6 +248,7 @@ func (u GuildMemberUpdateEvent) Update(m *discord.Member) {
 	m.RoleIDs = u.RoleIDs
 	m.User = u.User
 	m.Nick = u.Nick
+	m.Avatar = u.Avatar
 }
 
 // https://discord.com/developers/docs/topics/gateway#invites


### PR DESCRIPTION
Reference: discord/discord-api-docs#3081

(Had to break the pattern established by User.AvatarURL() and Guild.IconURL() etc, as the member object doesn't include a guild ID)