### PR TITLE
v3: fix(discord): fix json tag for Guild.Features

### DIFF
--- a/discord/guild.go
+++ b/discord/guild.go
@@ -62,7 +62,7 @@ type Guild struct {
 	// Emojis are the custom guild emojis.
 	Emojis []Emoji `json:"emojis"`
 	// Features are the enabled guild features.
-	Features []GuildFeature `json:"guild_features"`
+	Features []GuildFeature `json:"features"`
 
 	// AppID is the application id of the guild creator if it is bot-created.
 	//


### PR DESCRIPTION
Not sure when this occurred but I noticed it when my bot wouldn't get any features for Guilds. It has changed to `features` and can be seen [here](https://discord.com/developers/docs/resources/guild#get-guild) in the Discord API docs.