### PR TITLE
Gateway: Fix Context overwrite in Gateway.Open

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -14,13 +14,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gorilla/websocket"
+	"github.com/pkg/errors"
+
 	"github.com/diamondburned/arikawa/v3/api"
 	"github.com/diamondburned/arikawa/v3/internal/moreatomic"
 	"github.com/diamondburned/arikawa/v3/utils/json"
 	"github.com/diamondburned/arikawa/v3/utils/json/option"
 	"github.com/diamondburned/arikawa/v3/utils/wsutil"
-	"github.com/gorilla/websocket"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -359,9 +360,6 @@ func (g *Gateway) ReconnectCtx(ctx context.Context) (err error) {
 // this function over Start(). The given context provides cancellation and
 // timeout.
 func (g *Gateway) Open(ctx context.Context) error {
-	ctx, cancel := context.WithTimeout(context.Background(), g.WSTimeout)
-	defer cancel()
-
 	// Reconnect to the Gateway
 	if err := g.WS.Dial(ctx); err != nil {
 		return errors.Wrap(err, "failed to Reconnect")

--- a/utils/wsutil/ws.go
+++ b/utils/wsutil/ws.go
@@ -43,13 +43,6 @@ type Websocket struct {
 
 	sendLimiter *rate.Limiter
 	dialLimiter *rate.Limiter
-
-	// Constants. These must not be changed after the Websocket instance is used
-	// once, as they are not thread-safe.
-
-	// Timeout for connecting and writing to the Websocket, uses default
-	// WSTimeout (global).
-	Timeout time.Duration
 }
 
 // New creates a default Websocket with the given address.
@@ -66,20 +59,11 @@ func NewCustom(conn Connection, addr string) *Websocket {
 
 		sendLimiter: NewSendLimiter(),
 		dialLimiter: NewDialLimiter(),
-
-		Timeout: WSTimeout,
 	}
 }
 
 // Dial waits until the rate limiter allows then dials the websocket.
 func (ws *Websocket) Dial(ctx context.Context) error {
-	if ws.Timeout > 0 {
-		tctx, cancel := context.WithTimeout(ctx, ws.Timeout)
-		defer cancel()
-
-		ctx = tctx
-	}
-
 	if err := ws.dialLimiter.Wait(ctx); err != nil {
 		// Expired, fatal error
 		return errors.Wrap(err, "failed to wait")

--- a/utils/wsutil/ws.go
+++ b/utils/wsutil/ws.go
@@ -46,6 +46,8 @@ type Websocket struct {
 
 	// Timeout is the default timeout used if a context with no deadline is
 	// given to Dial.
+	//
+	// It must not be changed after the Websocket is used once.
 	Timeout time.Duration
 }
 
@@ -63,7 +65,8 @@ func NewCustom(conn Connection, addr string) *Websocket {
 
 		sendLimiter: NewSendLimiter(),
 		dialLimiter: NewDialLimiter(),
-		Timeout:     WSTimeout,
+
+		Timeout: WSTimeout,
 	}
 }
 


### PR DESCRIPTION
This PR fixes a bug where the `context.Context` given to `Gateway.Open` would always get overwritten with another context.
Furthermore, it removes a deadline maximum from `wsutil.Websocket.Dial`, which would limit the deadline of the context given to `Dial` to `Websocket.Timeout`, regardless of the deadline set by the caller.