### PR TITLE
Add Type to CommandInteractionOption

### DIFF
--- a/discord/interaction.go
+++ b/discord/interaction.go
@@ -312,6 +312,7 @@ func (*CommandInteraction) data() {}
 
 // CommandInteractionOption is an option for a Command interaction response.
 type CommandInteractionOption struct {
+	Type    CommandOptionType         `json:"type"`
 	Name    string                    `json:"name"`
 	Value   json.Raw                  `json:"value"`
 	Options CommandInteractionOptions `json:"options"`


### PR DESCRIPTION
When testing last night, I realized that Autocomplete Interactions send Types on their options. Confirmed both via docs and real-world tests that `type` is sent on CommandInteractionOptions as well.

The docs: https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-interaction-data-option-structure