### PR TITLE
discord: Add Icon/Emoji & Tags to Role

### DIFF
--- a/api/role.go
+++ b/api/role.go
@@ -70,6 +70,15 @@ type CreateRoleData struct {
 	// Default: false
 	Mentionable bool `json:"mentionable,omitempty"`
 
+	// Icon is the icon of the role. Requires the guild to have the ROLE_ICONS feature.
+	//
+	// Default: null
+	Icon *Image `json:"icon,omitempty"`
+	// UnicodeEmoji is the role's unicode emoji. Requires the guild to have the ROLE_ICONS feature. This value is nullable.
+	//
+	// Default: null
+	UnicodeEmoji string `json:"unicode_emoji,omitempty"`
+
 	AddRoleData `json:"-"`
 }
 
@@ -132,6 +141,11 @@ type ModifyRoleData struct {
 	Hoist option.NullableBool `json:"hoist,omitempty"`
 	// Mentionable specifies whether the role should be mentionable.
 	Mentionable option.NullableBool `json:"mentionable,omitempty"`
+
+	// Icon is the icon of the role. Requires the guild to have the ROLE_ICONS feature. This value is nullable.
+	Icon *Image `json:"icon,omitempty"`
+	// UnicodeEmoji is the role's unicode emoji. Requires the guild to have the ROLE_ICONS feature. This value is nullable.
+	UnicodeEmoji string `json:"unicode_emoji,omitempty"`
 
 	AddRoleData `json:"-"`
 }

--- a/api/role.go
+++ b/api/role.go
@@ -142,10 +142,12 @@ type ModifyRoleData struct {
 	// Mentionable specifies whether the role should be mentionable.
 	Mentionable option.NullableBool `json:"mentionable,omitempty"`
 
-	// Icon is the icon of the role. Requires the guild to have the ROLE_ICONS feature. This value is nullable.
+	// Icon is the icon of the role. Requires the guild to have the ROLE_ICONS feature.
+	// This value is nullable.
+	// To reset the role's icon, set this to NullImage.
 	Icon *Image `json:"icon,omitempty"`
-	// UnicodeEmoji is the role's unicode emoji. Requires the guild to have the ROLE_ICONS feature. This value is nullable.
-	UnicodeEmoji string `json:"unicode_emoji,omitempty"`
+	// UnicodeEmoji is the role's unicode emoji. Requires the guild to have the ROLE_ICONS feature.
+	UnicodeEmoji option.NullableString `json:"unicode_emoji,omitempty"`
 
 	AddRoleData `json:"-"`
 }

--- a/api/role.go
+++ b/api/role.go
@@ -74,7 +74,7 @@ type CreateRoleData struct {
 	//
 	// Default: null
 	Icon *Image `json:"icon,omitempty"`
-	// UnicodeEmoji is the role's unicode emoji. Requires the guild to have the ROLE_ICONS feature. This value is nullable.
+	// UnicodeEmoji is the role's unicode emoji. Requires the guild to have the ROLE_ICONS feature.
 	//
 	// Default: null
 	UnicodeEmoji string `json:"unicode_emoji,omitempty"`

--- a/discord/guild.go
+++ b/discord/guild.go
@@ -335,20 +335,20 @@ func (r Role) Mention() string {
 
 // IconURL returns the URL to the role icon png.
 // An empty string is returned if there's no icon.
-func (r Role) IconURL(guild GuildID) string {
-	return r.IconURLWithType(PNGImage, guild)
+func (r Role) IconURL() string {
+	return r.IconURLWithType(PNGImage)
 }
 
 // IconURLWithType returns the URL to the role icon using the passed
 // ImageType. An empty string is returned if there's no icon.
 //
 // Supported ImageTypes: PNG, JPEG, WebP
-func (r Role) IconURLWithType(t ImageType, guild GuildID) string {
+func (r Role) IconURLWithType(t ImageType) string {
 	if r.Icon == "" {
 		return ""
 	}
 
-	return "https://cdn.discordapp.com/role-icons/" + guild.String() + "/" + t.format(r.Icon)
+	return "https://cdn.discordapp.com/role-icons/" + r.ID.String() + "/" + t.format(r.Icon)
 }
 
 // https://discord.com/developers/docs/resources/guild#guild-member-object

--- a/discord/guild.go
+++ b/discord/guild.go
@@ -305,6 +305,22 @@ type Role struct {
 	Managed bool `json:"managed"`
 	// Mentionable specifies whether this role is mentionable.
 	Mentionable bool `json:"mentionable"`
+
+	// Icon is the icon hash of this role.
+	Icon Hash `json:"icon,omitempty"`
+	// UnicodeEmoji is the unicode emoji of this role.
+	UnicodeEmoji string `json:"unicode_emoji,omitempty"`
+	// Tags are the RoleTags of this role.
+	Tags RoleTags `json:"tags,omitempty"`
+}
+
+type RoleTags struct {
+	// BotID is the id of the bot this role belongs to.
+	BotID UserID `json:"bot_id,omitempty"`
+	// IntegrationID is the id of the integration this role belongs to.
+	IntegrationID IntegrationID `json:"integration_id,omitempty"`
+	// PremiumSubscriber specifies whether this is the guild's premium subscriber role.
+	PremiumSubscriber bool `json:"premium_subscriber,omitempty"`
 }
 
 // CreatedAt returns a time object representing when the role was created.
@@ -315,6 +331,24 @@ func (r Role) CreatedAt() time.Time {
 // Mention returns the mention of the Role.
 func (r Role) Mention() string {
 	return r.ID.Mention()
+}
+
+// IconURL returns the URL to the role icon png.
+// An empty string is returned if there's no icon.
+func (r Role) IconURL(guild GuildID) string {
+	return r.IconURLWithType(PNGImage, guild)
+}
+
+// IconURLWithType returns the URL to the role icon using the passed
+// ImageType. An empty string is returned if there's no icon.
+//
+// Supported ImageTypes: PNG, JPEG, WebP
+func (r Role) IconURLWithType(t ImageType, guild GuildID) string {
+	if r.Icon == "" {
+		return ""
+	}
+
+	return "https://cdn.discordapp.com/role-icons/" + guild.String() + "/" + t.format(r.Icon)
 }
 
 // https://discord.com/developers/docs/resources/guild#guild-member-object


### PR DESCRIPTION
PremiumSubscriber seems unused for now, the docs even have it typed as "null", but it is already in the docs so i decided to include it

This now also alters api, but I am not sure how to reflect that in the title