### PR TITLE
api: Add localization fields to Application Command creation data

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -19,13 +19,15 @@ func (c *Client) CurrentApplication() (*discord.Application, error) {
 	)
 }
 
-// https://discord.com/developers/docs/interactions/slash-commands#create-global-application-command-json-params
+// https://discord.com/developers/docs/interactions/application-commands#create-global-application-command
 type CreateCommandData struct {
-	Name                string                 `json:"name"`
-	Description         string                 `json:"description"`
-	Options             discord.CommandOptions `json:"options,omitempty"`
-	NoDefaultPermission bool                   `json:"-"`
-	Type                discord.CommandType    `json:"type,omitempty"`
+	Name                     string                 `json:"name"`
+	NameLocalizations        discord.StringLocales  `json:"name_localizations,omitempty"`
+	Description              string                 `json:"description"`
+	DescriptionLocalizations discord.StringLocales  `json:"description_localizations,omitempty"`
+	Options                  discord.CommandOptions `json:"options,omitempty"`
+	NoDefaultPermission      bool                   `json:"-"`
+	Type                     discord.CommandType    `json:"type,omitempty"`
 }
 
 func (c CreateCommandData) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
There was one mistake. (#321)
I missed the localization field when I generated the application command.

As I added the localization field, I also replaced the inactive official document link in the comments, so please check it.