### PR TITLE
Autocomplete Options changes

### DIFF
--- a/0-examples/autocomplete/main.go
+++ b/0-examples/autocomplete/main.go
@@ -42,7 +42,7 @@ func main() {
 				},
 			}
 		case *discord.AutocompleteInteraction:
-			allChoices := []api.AutocompleteChoice{
+			allChoices := api.AutocompleteStringChoices{
 				{Name: "Choice A", Value: "Choice A"},
 				{Name: "Choice B", Value: "Choice B"},
 				{Name: "Choice C", Value: "Choice C"},
@@ -51,8 +51,8 @@ func main() {
 				{Name: "Mno Pqr", Value: "Mnopqr"},
 				{Name: "Stu Vwx", Value: "Stuvwx"},
 			}
-			query := strings.ToLower(d.Options[0].Value)
-			var choices []api.AutocompleteChoice
+			query := strings.ToLower(d.Options[0].String())
+			var choices api.AutocompleteStringChoices
 			for _, choice := range allChoices {
 				if strings.HasPrefix(strings.ToLower(choice.Name), query) ||
 					strings.HasPrefix(strings.ToLower(choice.Value), query) {

--- a/api/interaction.go
+++ b/api/interaction.go
@@ -78,7 +78,7 @@ type InteractionResponseData struct {
 	// Choices are the results to display on autocomplete interaction events.
 	//
 	// During all other events, this should not be provided.
-	Choices *[]AutocompleteChoice `json:"choices"`
+	Choices AutocompleteChoices `json:"choices"`
 
 	// CustomID used with the modal
 	CustomID option.NullableString `json:"custom_id,omitempty"`
@@ -95,12 +95,36 @@ func (d InteractionResponseData) WriteMultipart(body *multipart.Writer) error {
 	return sendpart.Write(body, d, d.Files)
 }
 
-// AutocompleteChoice is the choice in ApplicationCommandAutocompleteResult in
-// the official documentation.
-type AutocompleteChoice struct {
-	Name  string `json:"name"`
-	Value string `json:"value"`
+// AutocompleteChoices are the choices to send back to Discord when sending a
+// ApplicationCommandAutocompleteResult interaction response.
+//
+// The following types implement this interface:
+//
+//    - AutocompleteStringChoices
+//    - AutocompleteIntegerChoices
+//    - AutocompleteNumberChoices
+//
+type AutocompleteChoices interface {
+	choices()
 }
+
+// AutocompleteStringChoices are string choices to send back to Discord as
+// autocomplete results.
+type AutocompleteStringChoices []discord.StringChoice
+
+func (c AutocompleteStringChoices) choices() {}
+
+// AutocompleteIntegerChoices are integer choices to send back to Discord as
+// autocomplete results.
+type AutocompleteIntegerChoices []discord.IntegerChoice
+
+func (c AutocompleteIntegerChoices) choices() {}
+
+// AutocompleteNumberChoices are number choices to send back to Discord as
+// autocomplete results.
+type AutocompleteNumberChoices []discord.NumberChoice
+
+func (c AutocompleteNumberChoices) choices() {}
 
 // RespondInteraction responds to an incoming interaction. It is also known as
 // an "interaction callback".

--- a/discord/interaction.go
+++ b/discord/interaction.go
@@ -202,14 +202,47 @@ func (o AutocompleteOptions) Find(name string) AutocompleteOption {
 type AutocompleteOption struct {
 	Type    CommandOptionType    `json:"type"`
 	Name    string               `json:"name"`
-	Value   string               `json:"value"`
+	Value   json.Raw             `json:"value"`
 	Focused bool                 `json:"focused"`
 	Options []AutocompleteOption `json:"options"`
 }
 
-// Type implements ComponentInteraction.
-func (*AutocompleteInteraction) InteractionType() InteractionDataType {
-	return AutocompleteInteractionType
+// String will return the value if the option's value is a valid string.
+// Otherwise, it will return the raw JSON value of the other type.
+func (o AutocompleteOption) String() string {
+	var value string
+	if err := json.Unmarshal(o.Value, &value); err != nil {
+		return string(o.Value)
+	}
+	return value
+}
+
+// IntValue reads the option's value as an int.
+func (o AutocompleteOption) IntValue() (int64, error) {
+	var i int64
+	err := o.Value.UnmarshalTo(&i)
+	return i, err
+}
+
+// BoolValue reads the option's value as a bool.
+func (o AutocompleteOption) BoolValue() (bool, error) {
+	var b bool
+	err := o.Value.UnmarshalTo(&b)
+	return b, err
+}
+
+// SnowflakeValue reads the option's value as a snowflake.
+func (o AutocompleteOption) SnowflakeValue() (Snowflake, error) {
+	var id Snowflake
+	err := o.Value.UnmarshalTo(&id)
+	return id, err
+}
+
+// FloatValue reads the option's value as a float64.
+func (o AutocompleteOption) FloatValue() (float64, error) {
+	var f float64
+	err := o.Value.UnmarshalTo(&f)
+	return f, err
 }
 
 // ComponentInteraction is a union component interaction response types. The

--- a/discord/interaction.go
+++ b/discord/interaction.go
@@ -172,10 +172,30 @@ type AutocompleteInteraction struct {
 	CommandID CommandID `json:"id"`
 
 	// Name of command autocomplete is triggered for.
-	Name        string               `json:"name"`
-	CommandType CommandType          `json:"type"`
-	Version     string               `json:"version"`
-	Options     []AutocompleteOption `json:"options"`
+	Name        string              `json:"name"`
+	CommandType CommandType         `json:"type"`
+	Version     string              `json:"version"`
+	Options     AutocompleteOptions `json:"options"`
+}
+
+// Type implements ComponentInteraction.
+func (*AutocompleteInteraction) InteractionType() InteractionDataType {
+	return AutocompleteInteractionType
+}
+func (*AutocompleteInteraction) data() {}
+
+// AutocompleteOptions is a list of autocompletion options.
+// Use `Find` to get your named autocompletion option.
+type AutocompleteOptions []AutocompleteOption
+
+// Find returns the named autocomplete option.
+func (o AutocompleteOptions) Find(name string) AutocompleteOption {
+	for _, opt := range o {
+		if strings.EqualFold(opt.Name, name) {
+			return opt
+		}
+	}
+	return AutocompleteOption{}
 }
 
 // AutocompleteOption is an autocompletion option in an AutocompleteInteraction.
@@ -191,7 +211,6 @@ type AutocompleteOption struct {
 func (*AutocompleteInteraction) InteractionType() InteractionDataType {
 	return AutocompleteInteractionType
 }
-func (*AutocompleteInteraction) data() {}
 
 // ComponentInteraction is a union component interaction response types. The
 // types can be whatever the constructors for this type will return.


### PR DESCRIPTION
Currently AutocompleteOption behaves as if the option can only be a string. This makes sense since only StringOption can be autocompleted, but AutocompleteInteraction provides all options, not just the focused StringOption that is being typed in. So the way it's currently written is limiting and would mean you need to convert from string to a given type if you want to use any of the other options' values in your autocomplete logic. This PR mimics the behaviour of CommandInteractionOption, not sure if there's a more elegant way than duplicating the methods to AutocompleteOption. These changes are breaking so not sure if you want it in v3.