### PR TITLE
Add AttachmentOption type

### DIFF
--- a/discord/command.go
+++ b/discord/command.go
@@ -310,6 +310,7 @@ const (
 	RoleOptionType
 	MentionableOptionType
 	NumberOptionType
+	AttachmentOptionType
 	maxOptionType // for bound checking
 )
 
@@ -328,6 +329,7 @@ const (
 //    - *RoleOption
 //    - *MentionableOption
 //    - *NumberOption
+//	  - *AttachmentOption
 //
 type CommandOption interface {
 	Name() string
@@ -430,6 +432,7 @@ func (s *SubcommandOption) UnmarshalJSON(b []byte) error {
 //    - *RoleOption
 //    - *MentionableOption
 //    - *NumberOption
+//    - *AttachmentOption
 //
 type CommandOptionValue interface {
 	CommandOption
@@ -653,6 +656,28 @@ type NumberChoice struct {
 	LocalizedName string `json:"name_localized,omitempty"`
 }
 
+// AttachmentOption is a subcommand option that fits into a CommandOptionValue.
+type AttachmentOption struct {
+	OptionName               string        `json:"name"`
+	OptionNameLocalizations  StringLocales `json:"name_localizations,omitempty"`
+	Description              string        `json:"description"`
+	DescriptionLocalizations StringLocales `json:"description_localizations,omitempty"`
+	Required                 bool          `json:"required"`
+	// LocalizedOptionName is only populated when this is received from
+	// Discord's API.
+	LocalizedOptionName string `json:"name_localized,omitempty"`
+	// LocalizedDescription is only populated when this is received from
+	// Discord's API.
+	LocalizedDescription string `json:"description_localized,omitempty"`
+}
+
+// Name implements CommandOption.
+func (n *AttachmentOption) Name() string { return n.OptionName }
+
+// Type implements CommandOptionValue.
+func (n *AttachmentOption) Type() CommandOptionType { return AttachmentOptionType }
+func (n *AttachmentOption) _val()                   {}
+
 // NewCommand creates a new command.
 func NewCommand(name, description string, options ...CommandOption) Command {
 	return Command{
@@ -871,5 +896,17 @@ func (n *NumberOption) MarshalJSON() ([]byte, error) {
 	}{
 		Type: n.Type(),
 		raw:  (*raw)(n),
+	})
+}
+
+// MarshalJSON marshals AttachmentOption to JSON with the "type" field.
+func (a *AttachmentOption) MarshalJSON() ([]byte, error) {
+	type raw AttachmentOption
+	return json.Marshal(struct {
+		Type CommandOptionType `json:"type"`
+		*raw
+	}{
+		Type: a.Type(),
+		raw:  (*raw)(a),
 	})
 }

--- a/discord/interaction.go
+++ b/discord/interaction.go
@@ -368,6 +368,8 @@ type CommandInteraction struct {
 		// Messages contains partial message objects. All fields without
 		// omitempty are presumably present.
 		Messages map[MessageID]Message `json:"messages,omitempty"`
+		// Attachments contains attachments objects.
+		Attachments map[AttachmentID]Attachment `json:"attachments,omitempty"`
 	}
 }
 


### PR DESCRIPTION
This PR adds a missing command option type which lets users attach files as a slash command option.
https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type