### PR TITLE
Fix comment spacing

### DIFF
--- a/discord/command.go
+++ b/discord/command.go
@@ -329,7 +329,7 @@ const (
 //    - *RoleOption
 //    - *MentionableOption
 //    - *NumberOption
-//	  - *AttachmentOption
+//    - *AttachmentOption
 //
 type CommandOption interface {
 	Name() string


### PR DESCRIPTION
Use spaces instead of tabs and spaces for consistent comment rendering.