### PR TITLE
Name Member guild ID params appropriately

### DIFF
--- a/discord/guild.go
+++ b/discord/guild.go
@@ -388,20 +388,20 @@ func (m Member) Mention() string {
 
 // AvatarURL returns the URL of the Avatar Image. It automatically detects a
 // suitable type.
-func (m Member) AvatarURL(guild GuildID) string {
-	return m.AvatarURLWithType(AutoImage, guild)
+func (m Member) AvatarURL(guildID GuildID) string {
+	return m.AvatarURLWithType(AutoImage, guildID)
 }
 
 // AvatarURLWithType returns the URL of the Avatar Image using the passed type.
 // If the member has no Avatar, an empty string will be returned.
 //
 // Supported Image Types: PNG, JPEG, WebP, GIF
-func (m Member) AvatarURLWithType(t ImageType, guild GuildID) string {
+func (m Member) AvatarURLWithType(t ImageType, guildID GuildID) string {
 	if m.Avatar == "" {
 		return ""
 	}
 
-	return "https://cdn.discordapp.com/guilds/" + guild.String() + "/users/" + m.User.ID.String() + "/avatars/" + t.format(m.Avatar)
+	return "https://cdn.discordapp.com/guilds/" + guildID.String() + "/users/" + m.User.ID.String() + "/avatars/" + t.format(m.Avatar)
 }
 
 // https://discord.com/developers/docs/resources/guild#ban-object


### PR DESCRIPTION
The parameter that needs to be passed to these Member.AvatarURL*() methods is a guild ID but the parameters are only named `guild`. This change renames the parameters to `guildID` - making the required parameters clearer at a glance.