### PR TITLE
Add Invite.URL() methods

### DIFF
--- a/discord/invite.go
+++ b/discord/invite.go
@@ -32,6 +32,16 @@ type Invite struct {
 	InviteMetadata
 }
 
+// URL returns a Discord invite URL linking to the invite.
+func (i Invite) URL() string {
+	return "https://discord.gg/" + i.Code
+}
+
+// LongURL returns a long-form Discord invite URL linking to the invite.
+func (i Invite) LongURL() string {
+	return "https://discord.com/invite/" + i.Code
+}
+
 // https://discord.com/developers/docs/resources/invite#invite-object-target-user-types
 type InviteUserType uint8
 


### PR DESCRIPTION
This PR adds two convenience methods for `Invite` that allow users to easily access the URL of an invite, similarly to `Message.URL()` and `Emoji.URL()` etc.