### PR TITLE
Fix json tag for Guild.MFA + create GuildMemberUpdateEvent.IsPending

### DIFF
--- a/discord/guild.go
+++ b/discord/guild.go
@@ -34,7 +34,7 @@ type Guild struct {
 	// NitroBoost is the premium tier (Server Boost level).
 	NitroBoost NitroBoost `json:"premium_tier"`
 	// MFA is the required MFA level for the guild.
-	MFA MFALevel `json:"mfa"`
+	MFA MFALevel `json:"mfa_level"`
 
 	// OwnerID is the id of owner.
 	OwnerID UserID `json:"owner_id"`

--- a/gateway/events.go
+++ b/gateway/events.go
@@ -308,6 +308,7 @@ type GuildMemberUpdateEvent struct {
 	User                       discord.User      `json:"user"`
 	Nick                       string            `json:"nick"`
 	Avatar                     discord.Hash      `json:"avatar"`
+	IsPending                  bool              `json:"pending,omitempty"`
 	CommunicationDisabledUntil discord.Timestamp `json:"communication_disabled_until"`
 }
 
@@ -317,6 +318,7 @@ func (u *GuildMemberUpdateEvent) UpdateMember(m *discord.Member) {
 	m.User = u.User
 	m.Nick = u.Nick
 	m.Avatar = u.Avatar
+	m.IsPending = u.IsPending
 	m.CommunicationDisabledUntil = u.CommunicationDisabledUntil
 }
 


### PR DESCRIPTION
This fixes some issues with struct fields:
- `Guild.MFA` had an incorrect name in the JSON tag: [`mfa` -> `mfa_level`](https://discord.com/developers/docs/resources/guild#guild-object-guild-structure)
- `GuildMemberUpdateEvent` didn't have a field for [`pending`](https://discord.com/developers/docs/topics/gateway#guild-member-update-guild-member-update-event-fields)