### PR TITLE
feat: add support for disabling signature verification

### DIFF
--- a/0-examples/commands-hybrid/main.go
+++ b/0-examples/commands-hybrid/main.go
@@ -56,7 +56,7 @@ func main() {
 	if webhookAddr != "" {
 		h.s = state.NewAPIOnlyState(token, nil)
 
-		srv, err := webhook.NewInteractionServer(webhookPubkey, &h)
+		srv, err := webhook.NewInteractionServer(webhookPubkey, &h, true)
 		if err != nil {
 			log.Fatalln("cannot create interaction server:", err)
 		}

--- a/0-examples/commands-hybrid/main.go
+++ b/0-examples/commands-hybrid/main.go
@@ -56,7 +56,7 @@ func main() {
 	if webhookAddr != "" {
 		h.s = state.NewAPIOnlyState(token, nil)
 
-		srv, err := webhook.NewInteractionServer(webhookPubkey, &h, true)
+		srv, err := webhook.NewInteractionServer(webhookPubkey, &h)
 		if err != nil {
 			log.Fatalln("cannot create interaction server:", err)
 		}

--- a/api/webhook/interactionserver.go
+++ b/api/webhook/interactionserver.go
@@ -116,11 +116,7 @@ func NewInteractionServer(pubkey string, handler InteractionHandler) (*Interacti
 
 // ServeHTTP implements http.Handler.
 func (s *InteractionServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if len(s.pubkey) != 0 {
-		s.withVerification(http.HandlerFunc(s.handle)).ServeHTTP(w, r)
-	} else {
-		http.HandlerFunc(s.handle).ServeHTTP(w, r)
-	}
+	s.httpHandler.ServeHTTP(w, r)
 }
 
 func (s *InteractionServer) handle(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
During local development it doesn't make a lot of sense to require signature verification.

Here's a proposed change that allows library users to disable verification. I'm open to alternative approaches in order to avoid introducing any breaking changes if there are concerns around that.