### PR TITLE
discord: Add new select components

### DIFF
--- a/discord/component_example_test.go
+++ b/discord/component_example_test.go
@@ -6,7 +6,6 @@ import (
 	"log"
 
 	"github.com/diamondburned/arikawa/v3/discord"
-	"github.com/diamondburned/arikawa/v3/utils/json/option"
 )
 
 func ExampleContainerComponents_Unmarshal() {
@@ -14,21 +13,21 @@ func ExampleContainerComponents_Unmarshal() {
 		&discord.ActionRowComponent{
 			&discord.TextInputComponent{
 				CustomID: "text1",
-				Value:    option.NewNullableString("hello"),
+				Value:    "hello",
 			},
 		},
 		&discord.ActionRowComponent{
 			&discord.TextInputComponent{
 				CustomID: "text2",
-				Value:    option.NewNullableString("hello 2"),
+				Value:    "hello 2",
 			},
 			&discord.TextInputComponent{
 				CustomID: "text3",
-				Value:    option.NewNullableString("hello 3"),
+				Value:    "hello 3",
 			},
 		},
 		&discord.ActionRowComponent{
-			&discord.SelectComponent{
+			&discord.StringSelectComponent{
 				CustomID: "select1",
 				Options: []discord.SelectOption{
 					{Value: "option 1"},
@@ -40,7 +39,7 @@ func ExampleContainerComponents_Unmarshal() {
 			},
 		},
 		&discord.ActionRowComponent{
-			&discord.SelectComponent{
+			&discord.StringSelectComponent{
 				CustomID: "select2",
 				Options: []discord.SelectOption{
 					{Value: "option 1"},

--- a/discord/interaction.go
+++ b/discord/interaction.go
@@ -305,7 +305,7 @@ type SelectInteraction struct {
 func (s *SelectInteraction) ID() ComponentID { return s.CustomID }
 
 // Type implements ComponentInteraction.
-func (s *SelectInteraction) Type() ComponentType { return SelectComponentType }
+func (s *SelectInteraction) Type() ComponentType { return StringSelectComponentType }
 
 // InteractionType implements InteractionData.
 func (s *SelectInteraction) InteractionType() InteractionDataType {
@@ -351,7 +351,7 @@ func ParseComponentInteraction(b []byte) (ComponentInteraction, error) {
 	switch t.Type {
 	case ButtonComponentType:
 		d = &ButtonInteraction{CustomID: t.CustomID}
-	case SelectComponentType:
+	case StringSelectComponentType:
 		d = &SelectInteraction{CustomID: t.CustomID}
 	default:
 		d = &UnknownComponent{


### PR DESCRIPTION
This pull request adds the [new select components](https://discord.com/developers/docs/change-log#new-select-menu-components). It also renames `SelectComponent` to `StringSelectComponent` in-line with the [documentation](https://discord.com/developers/docs/interactions/message-components#component-object-component-types). `TextInputComponent.Value` was also changed from `option.NullableString` to `string` as I don't see a reason for it to be optional - when you submit from a modal, the values in the text input components are sent to the API and then received as a `MESSAGE_COMPONENT` interaction event where the attached components have the same values submitted into the modal, so I can't see where it would need to be nullable?