### PR TITLE
discord: Add StringOption Min/MaxLength

### DIFF
--- a/discord/command.go
+++ b/discord/command.go
@@ -447,6 +447,8 @@ type StringOption struct {
 	DescriptionLocalizations StringLocales  `json:"description_localizations,omitempty"`
 	Required                 bool           `json:"required"`
 	Choices                  []StringChoice `json:"choices,omitempty"`
+	MinLength                option.Int     `json:"min_length,omitempty"`
+	MaxLength                option.Int     `json:"max_length,omitempty"`
 	// Autocomplete must not be true if Choices are present.
 	Autocomplete bool `json:"autocomplete"`
 	// LocalizedOptionName is only populated when this is received from


### PR DESCRIPTION
This pull request adds Min/MaxLength fields for `StringOption`, documented [here](https://discord.com/developers/docs/change-log#min-and-max-length-for-command-options). Min/Max fields for `IntegerOption` and `NumberOption` were also renamed to Min/MaxValue to differentiate better between `...Value` and `...Length` fields. This is breaking but makes them more accurate to the API and there may be breaking changes in #353 anyway.