### PR TITLE
Add omitempty tag for category id

### DIFF
--- a/api/channel.go
+++ b/api/channel.go
@@ -116,7 +116,7 @@ type (
 		// if moving to a new category.
 		LockPermissions option.Bool `json:"lock_permissions"`
 		// CategoryID is the new parent ID for the channel that is moved.
-		CategoryID discord.ChannelID `json:"parent_id"`
+		CategoryID discord.ChannelID `json:"parent_id,string,omitempty"`
 	}
 )
 


### PR DESCRIPTION
Without this, the category id field is a required parameter when requesting `MoveChannel` even though all I want to do is move the position of the channel.

This required parameter also causes an error when I try to move multiple channels at once.

```
Discord 400 error: Only one channel can have a parent_id modified at a time
```