### PR TITLE
fix(discord): VoiceState#RequestToSpeakTimestamp field is nullable

### DIFF
--- a/discord/voice.go
+++ b/discord/voice.go
@@ -18,7 +18,7 @@ type VoiceState struct {
 	SelfVideo  bool `json:"self_video,omitempty"`
 	Suppress   bool `json:"suppress"`
 
-	RequestToSpeakTimestamp Timestamp `json:"request_to_speak_timestamp"`
+	RequestToSpeakTimestamp *Timestamp `json:"request_to_speak_timestamp"`
 }
 
 type VoiceRegion struct {


### PR DESCRIPTION
Reference: https://discord.com/developers/docs/resources/voice