### PR TITLE
refactor(cmdroute)!: change data to resp

### DIFF
--- a/0-examples/commands-hybrid/main.go
+++ b/0-examples/commands-hybrid/main.go
@@ -109,13 +109,16 @@ func newHandler(s *state.State) *handler {
 	return h
 }
 
-func (h *handler) cmdPing(ctx context.Context, cmd cmdroute.CommandData) *api.InteractionResponseData {
-	return &api.InteractionResponseData{
-		Content: option.NewNullableString("Pong!"),
+func (h *handler) cmdPing(ctx context.Context, cmd cmdroute.CommandData) *api.InteractionResponse {
+	return &api.InteractionResponse{
+		Type: api.MessageInteractionWithSource,
+		Data: &api.InteractionResponseData{
+			Content: option.NewNullableString("Pong!"),
+		},
 	}
 }
 
-func (h *handler) cmdEcho(ctx context.Context, data cmdroute.CommandData) *api.InteractionResponseData {
+func (h *handler) cmdEcho(ctx context.Context, data cmdroute.CommandData) *api.InteractionResponse {
 	var options struct {
 		Arg string `discord:"argument"`
 	}
@@ -124,23 +127,32 @@ func (h *handler) cmdEcho(ctx context.Context, data cmdroute.CommandData) *api.I
 		return errorResponse(err)
 	}
 
-	return &api.InteractionResponseData{
-		Content:         option.NewNullableString(options.Arg),
-		AllowedMentions: &api.AllowedMentions{}, // don't mention anyone
+	return &api.InteractionResponse{
+		Type: api.MessageInteractionWithSource,
+		Data: &api.InteractionResponseData{
+			Content:         option.NewNullableString(options.Arg),
+			AllowedMentions: &api.AllowedMentions{}, // don't mention anyone
+		},
 	}
 }
 
-func (h *handler) cmdThonk(ctx context.Context, data cmdroute.CommandData) *api.InteractionResponseData {
+func (h *handler) cmdThonk(ctx context.Context, data cmdroute.CommandData) *api.InteractionResponse {
 	time.Sleep(time.Duration(3+rand.Intn(5)) * time.Second)
-	return &api.InteractionResponseData{
-		Content: option.NewNullableString("https://tenor.com/view/thonk-thinking-sun-thonk-sun-thinking-sun-gif-14999983"),
+	return &api.InteractionResponse{
+		Type: api.MessageInteractionWithSource,
+		Data: &api.InteractionResponseData{
+			Content: option.NewNullableString("https://tenor.com/view/thonk-thinking-sun-thonk-sun-thinking-sun-gif-14999983"),
+		},
 	}
 }
 
-func errorResponse(err error) *api.InteractionResponseData {
-	return &api.InteractionResponseData{
-		Content:         option.NewNullableString("**Error:** " + err.Error()),
-		Flags:           discord.EphemeralMessage,
-		AllowedMentions: &api.AllowedMentions{ /* none */ },
+func errorResponse(err error) *api.InteractionResponse {
+	return &api.InteractionResponse{
+		Type: api.MessageInteractionWithSource,
+		Data: &api.InteractionResponseData{
+			Content:         option.NewNullableString("**Error:** " + err.Error()),
+			Flags:           discord.EphemeralMessage,
+			AllowedMentions: &api.AllowedMentions{ /* none */ },
+		},
 	}
 }

--- a/0-examples/commands-minimal/main.go
+++ b/0-examples/commands-minimal/main.go
@@ -16,8 +16,13 @@ var commands = []api.CreateCommandData{{Name: "ping", Description: "Ping!"}}
 
 func main() {
 	r := cmdroute.NewRouter()
-	r.AddFunc("ping", func(ctx context.Context, data cmdroute.CommandData) *api.InteractionResponseData {
-		return &api.InteractionResponseData{Content: option.NewNullableString("Pong!")}
+	r.AddFunc("ping", func(ctx context.Context, data cmdroute.CommandData) *api.InteractionResponse {
+		return &api.InteractionResponse{
+			Type: api.MessageInteractionWithSource,
+			Data: &api.InteractionResponseData{
+				Content: option.NewNullableString("Pong!"),
+			},
+		}
 	})
 
 	s := state.New("Bot " + os.Getenv("BOT_TOKEN"))

--- a/0-examples/commands/main.go
+++ b/0-examples/commands/main.go
@@ -88,13 +88,16 @@ func newHandler(s *state.State) *handler {
 	return h
 }
 
-func (h *handler) cmdPing(ctx context.Context, cmd cmdroute.CommandData) *api.InteractionResponseData {
-	return &api.InteractionResponseData{
-		Content: option.NewNullableString("Pong!"),
+func (h *handler) cmdPing(ctx context.Context, cmd cmdroute.CommandData) *api.InteractionResponse {
+	return &api.InteractionResponse{
+		Type: api.MessageInteractionWithSource,
+		Data: &api.InteractionResponseData{
+			Content: option.NewNullableString("Pong!"),
+		},
 	}
 }
 
-func (h *handler) cmdEcho(ctx context.Context, data cmdroute.CommandData) *api.InteractionResponseData {
+func (h *handler) cmdEcho(ctx context.Context, data cmdroute.CommandData) *api.InteractionResponse {
 	var options struct {
 		Arg string `discord:"argument"`
 	}
@@ -103,23 +106,32 @@ func (h *handler) cmdEcho(ctx context.Context, data cmdroute.CommandData) *api.I
 		return errorResponse(err)
 	}
 
-	return &api.InteractionResponseData{
-		Content:         option.NewNullableString(options.Arg),
-		AllowedMentions: &api.AllowedMentions{}, // don't mention anyone
+	return &api.InteractionResponse{
+		Type: api.MessageInteractionWithSource,
+		Data: &api.InteractionResponseData{
+			Content:         option.NewNullableString(options.Arg),
+			AllowedMentions: &api.AllowedMentions{}, // don't mention anyone
+		},
 	}
 }
 
-func (h *handler) cmdThonk(ctx context.Context, data cmdroute.CommandData) *api.InteractionResponseData {
+func (h *handler) cmdThonk(ctx context.Context, data cmdroute.CommandData) *api.InteractionResponse {
 	time.Sleep(time.Duration(3+rand.Intn(5)) * time.Second)
-	return &api.InteractionResponseData{
-		Content: option.NewNullableString("https://tenor.com/view/thonk-thinking-sun-thonk-sun-thinking-sun-gif-14999983"),
+	return &api.InteractionResponse{
+		Type: api.MessageInteractionWithSource,
+		Data: &api.InteractionResponseData{
+			Content: option.NewNullableString("https://tenor.com/view/thonk-thinking-sun-thonk-sun-thinking-sun-gif-14999983"),
+		},
 	}
 }
 
-func errorResponse(err error) *api.InteractionResponseData {
-	return &api.InteractionResponseData{
-		Content:         option.NewNullableString("**Error:** " + err.Error()),
-		Flags:           discord.EphemeralMessage,
-		AllowedMentions: &api.AllowedMentions{ /* none */ },
+func errorResponse(err error) *api.InteractionResponse {
+	return &api.InteractionResponse{
+		Type: api.MessageInteractionWithSource,
+		Data: &api.InteractionResponseData{
+			Content:         option.NewNullableString("**Error:** " + err.Error()),
+			Flags:           discord.EphemeralMessage,
+			AllowedMentions: &api.AllowedMentions{ /* none */ },
+		},
 	}
 }

--- a/api/cmdroute/fntypes.go
+++ b/api/cmdroute/fntypes.go
@@ -50,16 +50,16 @@ type CommandHandler interface {
 	// handler does not return a response within the deadline, the response will
 	// be automatically deferred in a goroutine, and the returned response will
 	// be sent to the user through the API instead.
-	HandleCommand(ctx context.Context, data CommandData) *api.InteractionResponseData
+	HandleCommand(ctx context.Context, data CommandData) *api.InteractionResponse
 }
 
 // CommandHandlerFunc is a function that implements CommandHandler.
-type CommandHandlerFunc func(ctx context.Context, data CommandData) *api.InteractionResponseData
+type CommandHandlerFunc func(ctx context.Context, data CommandData) *api.InteractionResponse
 
 var _ CommandHandler = CommandHandlerFunc(nil)
 
 // HandleCommand implements CommandHandler.
-func (f CommandHandlerFunc) HandleCommand(ctx context.Context, data CommandData) *api.InteractionResponseData {
+func (f CommandHandlerFunc) HandleCommand(ctx context.Context, data CommandData) *api.InteractionResponse {
 	return f(ctx, data)
 }
 

--- a/api/cmdroute/router.go
+++ b/api/cmdroute/router.go
@@ -135,18 +135,15 @@ func (r *Router) HandleCommand(ev *discord.InteractionEvent, data *discord.Comma
 func (r *Router) handleCommand(ev *discord.InteractionEvent, found handlerData) *api.InteractionResponse {
 	return r.handleInteraction(ev,
 		func(ctx context.Context, ev *discord.InteractionEvent) *api.InteractionResponse {
-			data := found.handler.HandleCommand(ctx, CommandData{
+			resp := found.handler.HandleCommand(ctx, CommandData{
 				CommandInteractionOption: found.data,
 				Event:                    ev,
 			})
-			if data == nil {
+			if resp == nil {
 				return nil
 			}
 
-			return &api.InteractionResponse{
-				Type: api.MessageInteractionWithSource,
-				Data: data,
-			}
+			return resp
 		},
 	)
 }


### PR DESCRIPTION
changes `cmdroute` to work with `*api.InteractionResponse` instead of `*api.InteractionResponseData`

this would allow to return modals via command interactions done through `cmdroute`

this PR is a breaking change
