### PR TITLE
discord: add missing fields to MessageType enum

### DIFF
--- a/discord/message.go
+++ b/discord/message.go
@@ -164,6 +164,16 @@ const (
 	GuildInviteReminderMessage
 	ContextMenuCommand
 	AutoModerationActionMessage
+	RoleSubscriptionPurchaseMessage
+	InteractionPremiumUpsellMessage
+
+	StageStartMessage
+	StageEndMessage
+	StageSpeakerMessage
+	_
+	StageTopicMessage
+
+	GuildApplicationPremiumSubscriptionMessage
 )
 
 type MessageFlags enum.Enum


### PR DESCRIPTION
Related: https://github.com/discord/discord-api-docs/pull/5927