### PR TITLE
discord: add missing permissions

### DIFF
--- a/discord/permission.go
+++ b/discord/permission.go
@@ -91,6 +91,16 @@ const (
 	PermissionStartEmbeddedActivities
 	// Allows for timing out users
 	PermissionModerateMembers
+	// Allows for viewing role subscription insights
+	PermissionViewCreatorMonetizationAnalytics
+	// Allows for using soundboard in a voice channel
+	PermissionUseSoundboard
+	_
+	_
+	// Allows the usage of custom soundboard sounds from other servers
+	PermissionUseExternalSounds
+	// Allows sending voice messages
+	PermissionSendVoiceMessages
 
 	PermissionAllText = 0 |
 		PermissionViewChannel |


### PR DESCRIPTION
Reference: https://discord.com/developers/docs/topics/permissions#permissions-bitwise-permission-flags
Related: https://github.com/discord/discord-api-docs/pull/6039
