### PR TITLE
Fix the calculation of a default user avatar index

### DIFF
--- a/discord/user.go
+++ b/discord/user.go
@@ -91,7 +91,7 @@ func (u User) AvatarURLWithType(t ImageType) string {
 			}
 			picNo = strconv.Itoa(disc % 5)
 		} else {
-			picNo = strconv.FormatUint(uint64(u.ID>>22)%5, 10)
+			picNo = strconv.FormatUint(uint64(u.ID >> 22) % 6, 10)
 		}
 
 		return "https://cdn.discordapp.com/embed/avatars/" + picNo + ".png"

--- a/discord/user.go
+++ b/discord/user.go
@@ -91,7 +91,7 @@ func (u User) AvatarURLWithType(t ImageType) string {
 			}
 			picNo = strconv.Itoa(disc % 5)
 		} else {
-			picNo = strconv.FormatUint(uint64(u.ID >> 22) % 6, 10)
+			picNo = strconv.FormatUint(uint64(u.ID>>22)%6, 10)
 		}
 
 		return "https://cdn.discordapp.com/embed/avatars/" + picNo + ".png"


### PR DESCRIPTION
Closes #397
For users that migrated their username, the calculation of a default avatar index should be done with `(userID >> 22) % 6`, not `% 5`.
[Discord documentation](https://discord.com/developers/docs/reference#image-formatting-cdn-endpoints)