### PR TITLE
state: Use store roles for calculating overrides

### DIFF
--- a/discord/permission.go
+++ b/discord/permission.go
@@ -170,21 +170,23 @@ func (p Permissions) Add(perm Permissions) Permissions {
 	return p | perm
 }
 
-func CalcOverwrites(guild Guild, channel Channel, member Member) Permissions {
+func CalcOverrides(
+	guild Guild, channel Channel, member Member, roles []Role) Permissions {
+
 	if guild.OwnerID == member.User.ID {
 		return PermissionAll
 	}
 
 	var perm Permissions
 
-	for _, role := range guild.Roles {
+	for _, role := range roles {
 		if role.ID == RoleID(guild.ID) {
 			perm |= role.Permissions
 			break
 		}
 	}
 
-	for _, role := range guild.Roles {
+	for _, role := range roles {
 		for _, id := range member.RoleIDs {
 			if id == role.ID {
 				perm |= role.Permissions


### PR DESCRIPTION
Currently, the state.Permissions() helper method uses Guild.Roles to calculate the permission overrides. Guild.Roles aren't updated by Guild Role Update events, so this can result in the helper method giving unexpected results when a role was updated, but no Guild Update event has happened since. This change pulls roles from store.Roles() in the helper method, and passes them to the CalcOverrides method, which now uses the passed in roles instead of Guild.Roles.