### PR TITLE
state: Add missing error check

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -362,6 +362,9 @@ func (s *State) Permissions(
 	if merr != nil {
 		return 0, fmt.Errorf("failed to get member: %w", merr)
 	}
+	if rerr != nil {
+		return 0, fmt.Errorf("failed to get roles: %w", rerr)
+	}
 
 	return discord.CalcOverrides(*g, *ch, *m, rs), nil
 }


### PR DESCRIPTION
Adds missing check for error fetching roles in `State.Permissions()`.