### PR TITLE
discord: add AttachmentOption unmarshalling

### DIFF
--- a/discord/command.go
+++ b/discord/command.go
@@ -280,6 +280,8 @@ func (u *UnknownCommandOption) UnmarshalJSON(b []byte) error {
 		u.data = &MentionableOption{}
 	case NumberOptionType:
 		u.data = &NumberOption{}
+	case AttachmentOptionType:
+		u.data = &AttachmentOption{}
 	default:
 		// Copy the blob of bytes into a new slice.
 		u.raw = append(json.Raw(nil), b...)


### PR DESCRIPTION
`AttachmentOption` isn't in `UnknownCommandOption` so it doesn't get unmarshalled properly.

```go
func main() {
	var options discord.CommandOptions
	options.UnmarshalJSON([]byte(`[{"Type": 11, "Name": "attachment", "Description": "attachment"}]`))
	fmt.Println(reflect.TypeOf(options[0]))
}
```
> *discord.UnknownCommandOption