### PR TITLE
api: add ID to CreateCommandData

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -20,7 +20,9 @@ func (c *Client) CurrentApplication() (*discord.Application, error) {
 }
 
 // https://discord.com/developers/docs/interactions/application-commands#create-global-application-command
+// https://discord.com/developers/docs/interactions/application-commands#bulk-overwrite-guild-application-commands
 type CreateCommandData struct {
+	ID                       discord.CommandID      `json:"id,omitempty"`
 	Name                     string                 `json:"name"`
 	NameLocalizations        discord.StringLocales  `json:"name_localizations,omitempty"`
 	Description              string                 `json:"description"`


### PR DESCRIPTION
`CreateCommandData` doesn't have an ID parameter, adding it allows you to rename commands with `BulkOverwriteCommands` and `BulkOverwriteGuildCommands`.
```go
func main() {
	client := api.NewClient("Bot " + token)

	var cmds []api.CreateCommandData
	cmds = append(cmds, api.CreateCommandData{
		Type:        1,
		Name:        "newcommand",
		Description: "this is a fresh new command",
	})

	app, _ := client.CurrentApplication()

	newCmds, _ := client.BulkOverwriteGuildCommands(app.ID, testGuild, cmds)

	fmt.Printf("%d, '%s', '%s'\n", newCmds[0].ID, newCmds[0].Name, newCmds[0].Description)

	cmds[0] = api.CreateCommandData{
		ID:          newCmds[0].ID,
		Type:        1,
		Name:        "replacedcommand",
		Description: "this is an overwritten command",
	}

	newCmds, _ = client.BulkOverwriteGuildCommands(app.ID, testGuild, cmds)

	fmt.Printf("%d, '%s', '%s'\n", newCmds[0].ID, newCmds[0].Name, newCmds[0].Description)

	client.DeleteGuildCommand(app.ID, guildID, newCmds[0].ID)
}
```
> 1193307101997580370, 'newcommand', 'this is a fresh new command'
> 1193307101997580370, 'replacedcommand', 'this is an overwritten command'