### PR TITLE
fix unmarshal IntegerOption

### DIFF
--- a/discord/interaction.go
+++ b/discord/interaction.go
@@ -553,9 +553,8 @@ func optionKindSwitch(kind reflect.Kind, typ CommandOptionType) (expectType Comm
 		return StringOptionType
 	case reflect.Bool:
 		return BooleanOptionType
-	default:
 	}
-	return
+	return typ
 }
 
 // Unmarshal unmarshals the options into the struct pointer v. Each struct field


### PR DESCRIPTION
The update of #372 was not made, so I wrote the code myself.

Use a `switch` instead of a `map` to verify the type.