### PR TITLE
discord: Added SelectedValue fields for Channel, Mentionable, User and Role SelectComponents

### DIFF
--- a/discord/component.go
+++ b/discord/component.go
@@ -771,6 +771,8 @@ type RoleSelectComponent struct {
 	ValueLimits [2]int `json:"-"`
 	// Disabled disables the select if true.
 	Disabled bool `json:"disabled,omitempty"`
+	// SelectedRoles is the slice of RoleIDs that are marked as selected by default
+	SelectedRoles []RoleID `json:"-"`
 }
 
 // ID implements the Component interface.
@@ -788,17 +790,33 @@ func (s *RoleSelectComponent) _icp() {}
 func (s *RoleSelectComponent) MarshalJSON() ([]byte, error) {
 	type sel RoleSelectComponent
 
+	type DefaultValue struct {
+		Id RoleID `json:"id"`
+		Type string `json:"type"`
+	}
+
 	type Msg struct {
 		Type ComponentType `json:"type"`
 		*sel
 		MinValues *int `json:"min_values,omitempty"`
 		MaxValues *int `json:"max_values,omitempty"`
+		DefaultValues []DefaultValue `json:"default_values,omitempty"`
 	}
 
 	msg := Msg{
 		Type: RoleSelectComponentType,
 		sel:  (*sel)(s),
 	}
+
+	var defaultValues []DefaultValue
+
+	if len(s.SelectedRoles) > 0 {
+		for _, roleId := range s.SelectedRoles {
+			defaultValues = append(defaultValues, DefaultValue{Id: roleId, Type: "role"})
+		}
+	}
+
+	msg.DefaultValues = defaultValues
 
 	if s.ValueLimits != [2]int{0, 0} {
 		msg.MinValues = new(int)
@@ -822,6 +840,8 @@ type MentionableSelectComponent struct {
 	ValueLimits [2]int `json:"-"`
 	// Disabled disables the select if true.
 	Disabled bool `json:"disabled,omitempty"`
+	// SelectedUsers is the slice of UserIDs that are marked as selected by default
+	SelectedUsers []UserID `json:"-"`
 }
 
 // ID implements the Component interface.
@@ -839,17 +859,33 @@ func (s *MentionableSelectComponent) _icp() {}
 func (s *MentionableSelectComponent) MarshalJSON() ([]byte, error) {
 	type sel MentionableSelectComponent
 
+	type DefaultValue struct {
+		Id UserID `json:"id"`
+		Type string `json:"type"`
+	}
+
 	type Msg struct {
 		Type ComponentType `json:"type"`
 		*sel
 		MinValues *int `json:"min_values,omitempty"`
 		MaxValues *int `json:"max_values,omitempty"`
+		DefaultValues []DefaultValue `json:"default_values,omitempty"`
 	}
 
 	msg := Msg{
 		Type: MentionableSelectComponentType,
 		sel:  (*sel)(s),
 	}
+
+	var defaultValues []DefaultValue
+
+	if len(s.SelectedUsers) > 0 {
+		for _, userId := range s.SelectedUsers {
+			defaultValues = append(defaultValues, DefaultValue{Id: userId, Type: "user"})
+		}
+	}
+
+	msg.DefaultValues = defaultValues
 
 	if s.ValueLimits != [2]int{0, 0} {
 		msg.MinValues = new(int)
@@ -875,6 +911,8 @@ type ChannelSelectComponent struct {
 	Disabled bool `json:"disabled,omitempty"`
 	// ChannelTypes is the types of channels that can be chosen from.
 	ChannelTypes []ChannelType `json:"channel_types,omitempty"`
+	// SelectedChannels is the list of channels that are marked as selected by default.
+	SelectedChannels []ChannelID `json:"-"`
 }
 
 // ID implements the Component interface.
@@ -892,17 +930,33 @@ func (s *ChannelSelectComponent) _icp() {}
 func (s *ChannelSelectComponent) MarshalJSON() ([]byte, error) {
 	type sel ChannelSelectComponent
 
+	type DefaultValue struct {
+		Id ChannelID `json:"id"`
+		Type string `json:"type"`
+	}
+
 	type Msg struct {
 		Type ComponentType `json:"type"`
 		*sel
 		MinValues *int `json:"min_values,omitempty"`
 		MaxValues *int `json:"max_values,omitempty"`
+		DefaultValues []DefaultValue `json:"default_values,omitempty"`
 	}
 
 	msg := Msg{
 		Type: ChannelSelectComponentType,
 		sel:  (*sel)(s),
 	}
+
+	var defaultValues []DefaultValue
+
+	if len(s.SelectedChannels) > 0 {
+		for _, channelId := range s.SelectedChannels {
+			defaultValues = append(defaultValues, DefaultValue{Id: channelId, Type: "channel"})
+		}
+	}
+
+	msg.DefaultValues = defaultValues
 
 	if s.ValueLimits != [2]int{0, 0} {
 		msg.MinValues = new(int)

--- a/discord/component.go
+++ b/discord/component.go
@@ -858,7 +858,7 @@ type MentionableSelectComponent struct {
 	ValueLimits [2]int `json:"-"`
 	// Disabled disables the select if true.
 	Disabled bool `json:"disabled,omitempty"`
-	// DefaultMentions is the slice of discord.UserID's and discord.RoleID's 
+	// SelectedMentions is the slice of discord.UserID's and discord.RoleID's 
 	// that are marked as selected by default
 	SelectedMentions []interface{} `json:"-"`
 }

--- a/discord/component.go
+++ b/discord/component.go
@@ -853,13 +853,13 @@ type DefaultMention struct {
 	roleId RoleID `json:"-"`
 }
 
-// Creates new DefaultMention type with only UserID
-func UserMention (userId UserID) DefaultMention {
+// Creates new DefaultUserMention type with only UserID
+func DefaultUserMention (userId UserID) DefaultMention {
 	return DefaultMention{userId: userId}
 }
 
-// Creates new DefaultMention type with only RoleID
-func RoleMention(roleId RoleID) DefaultMention {
+// Creates new DefaultRoleMention type with only RoleID
+func DefaultRoleMention(roleId RoleID) DefaultMention {
 	return DefaultMention{roleId: roleId}
 }
 
@@ -876,7 +876,11 @@ type MentionableSelectComponent struct {
 	Disabled bool `json:"disabled,omitempty"`
 	// DefaultMentions is the slice of User / Role Mentions that are selected by default
 	// Example:
-	// DefaultMentions: []DefaultMention{ discord.UserMention(0382080830233), discord.RoleMention(4820380382080) }
+	//     DefaultMentions: []DefaultMention{ 
+	//         discord.DefaultUserMention(0382080830233), 
+	// 	       discord.DefaultRoleMention(4820380382080),
+	//         ...
+	//     }
 	DefaultMentions []DefaultMention `json:"-"`
 }
 

--- a/discord/component.go
+++ b/discord/component.go
@@ -876,7 +876,7 @@ type MentionableSelectComponent struct {
 	Disabled bool `json:"disabled,omitempty"`
 	// DefaultMentions is the slice of User / Role Mentions that are selected by default
 	// Example:
-	// DefaultMentions: []DefaultMention{ NewUserMention(0382080830233), NewRoleMention(4820380382080) }
+	// DefaultMentions: []DefaultMention{ discord.UserMention(0382080830233), discord.RoleMention(4820380382080) }
 	DefaultMentions []DefaultMention `json:"-"`
 }
 

--- a/discord/component.go
+++ b/discord/component.go
@@ -720,8 +720,8 @@ type UserSelectComponent struct {
 	ValueLimits [2]int `json:"-"`
 	// Disabled disables the select if true.
 	Disabled bool `json:"disabled,omitempty"`
-	// SelectedUsers is the slice of UserIDs that are marked as selected by default
-	SelectedUsers []UserID `json:"-"`
+	// DefaultUsers is the slice of UserIDs that are marked as selected by default
+	DefaultUsers []UserID `json:"-"`
 }
 
 // ID implements the Component interface.
@@ -759,8 +759,8 @@ func (s *UserSelectComponent) MarshalJSON() ([]byte, error) {
 
 	var defaultValues []DefaultValue
 
-	if len(s.SelectedUsers) > 0 {
-		for _, userId := range s.SelectedUsers {
+	if len(s.DefaultUsers) > 0 {
+		for _, userId := range s.DefaultUsers {
 			defaultValues = append(defaultValues, DefaultValue{Id: userId, Type: "user"})
 		}
 	}
@@ -789,8 +789,8 @@ type RoleSelectComponent struct {
 	ValueLimits [2]int `json:"-"`
 	// Disabled disables the select if true.
 	Disabled bool `json:"disabled,omitempty"`
-	// SelectedRoles is the slice of RoleIDs that are marked as selected by default
-	SelectedRoles []RoleID `json:"-"`
+	// DefaultRoles is the slice of RoleIDs that are marked as selected by default
+	DefaultRoles []RoleID `json:"-"`
 }
 
 // ID implements the Component interface.
@@ -828,8 +828,8 @@ func (s *RoleSelectComponent) MarshalJSON() ([]byte, error) {
 
 	var defaultValues []DefaultValue
 
-	if len(s.SelectedRoles) > 0 {
-		for _, roleId := range s.SelectedRoles {
+	if len(s.DefaultRoles) > 0 {
+		for _, roleId := range s.DefaultRoles {
 			defaultValues = append(defaultValues, DefaultValue{Id: roleId, Type: "role"})
 		}
 	}
@@ -858,9 +858,11 @@ type MentionableSelectComponent struct {
 	ValueLimits [2]int `json:"-"`
 	// Disabled disables the select if true.
 	Disabled bool `json:"disabled,omitempty"`
-	// SelectedMentions is the slice of discord.UserID's and discord.RoleID's 
+	// DefaultMentions is the slice of discord.UserID's and discord.RoleID's 
 	// that are marked as selected by default
-	SelectedMentions []interface{} `json:"-"`
+	// Example: 
+	// DefaultMentions: []interface{}{ discord.RoleID(78402180381208302), discord.UserID(87028080234556) }
+	DefaultMentions []interface{} `json:"-"`
 }
 
 // ID implements the Component interface.
@@ -898,8 +900,8 @@ func (s *MentionableSelectComponent) MarshalJSON() ([]byte, error) {
 
 	var defaultValues []DefaultValue
 
-	if len(s.SelectedMentions) > 0 {
-		for _, mentionId := range s.SelectedMentions {
+	if len(s.DefaultMentions) > 0 {
+		for _, mentionId := range s.DefaultMentions {
 			switch id := mentionId.(type) {
 			case UserID:
 				defaultValues = 
@@ -937,8 +939,8 @@ type ChannelSelectComponent struct {
 	Disabled bool `json:"disabled,omitempty"`
 	// ChannelTypes is the types of channels that can be chosen from.
 	ChannelTypes []ChannelType `json:"channel_types,omitempty"`
-	// SelectedChannels is the list of channels that are marked as selected by default.
-	SelectedChannels []ChannelID `json:"-"`
+	// DefaultChannels is the list of channels that are marked as selected by default.
+	DefaultChannels []ChannelID `json:"-"`
 }
 
 // ID implements the Component interface.
@@ -976,8 +978,8 @@ func (s *ChannelSelectComponent) MarshalJSON() ([]byte, error) {
 
 	var defaultValues []DefaultValue
 
-	if len(s.SelectedChannels) > 0 {
-		for _, channelId := range s.SelectedChannels {
+	if len(s.DefaultChannels) > 0 {
+		for _, channelId := range s.DefaultChannels {
 			defaultValues = append(defaultValues, DefaultValue{Id: channelId, Type: "channel"})
 		}
 	}

--- a/discord/component.go
+++ b/discord/component.go
@@ -847,6 +847,22 @@ func (s *RoleSelectComponent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(msg)
 }
 
+// DefaultMention type is a Union type which packs both UserID and RoleID
+type DefaultMention struct {
+	userId UserID `json:"-"`
+	roleId RoleID `json:"-"`
+}
+
+// Creates new DefaultMention type with only UserID
+func UserMention (userId UserID) DefaultMention {
+	return DefaultMention{userId: userId}
+}
+
+// Creates new DefaultMention type with only RoleID
+func RoleMention(roleId RoleID) DefaultMention {
+	return DefaultMention{roleId: roleId}
+}
+
 type MentionableSelectComponent struct {
 	// CustomID is the custom unique ID.
 	CustomID ComponentID `json:"custom_id,omitempty"`
@@ -858,11 +874,10 @@ type MentionableSelectComponent struct {
 	ValueLimits [2]int `json:"-"`
 	// Disabled disables the select if true.
 	Disabled bool `json:"disabled,omitempty"`
-	// DefaultMentions is the slice of discord.UserID's and discord.RoleID's 
-	// that are marked as selected by default
-	// Example: 
-	// DefaultMentions: []interface{}{ discord.RoleID(78402180381208302), discord.UserID(87028080234556) }
-	DefaultMentions []interface{} `json:"-"`
+	// DefaultMentions is the slice of User / Role Mentions that are selected by default
+	// Example:
+	// DefaultMentions: []DefaultMention{ NewUserMention(0382080830233), NewRoleMention(4820380382080) }
+	DefaultMentions []DefaultMention `json:"-"`
 }
 
 // ID implements the Component interface.
@@ -901,14 +916,14 @@ func (s *MentionableSelectComponent) MarshalJSON() ([]byte, error) {
 	var defaultValues []DefaultValue
 
 	if len(s.DefaultMentions) > 0 {
-		for _, mentionId := range s.DefaultMentions {
-			switch id := mentionId.(type) {
-			case UserID:
+		for _, mention := range s.DefaultMentions {
+			if mention.userId.IsValid() {
 				defaultValues = 
-					append(defaultValues, DefaultValue{Id: Snowflake(id), Type: "user"})
-			case RoleID:
+					append(defaultValues, DefaultValue{Id: Snowflake(mention.userId), Type: "user"})
+			}
+			if mention.roleId.IsValid() {
 				defaultValues = 
-					append(defaultValues, DefaultValue{Id: Snowflake(id), Type: "role"})
+					append(defaultValues, DefaultValue{Id: Snowflake(mention.roleId), Type: "role"})
 			}
 		}
 	}

--- a/discord/component.go
+++ b/discord/component.go
@@ -853,12 +853,12 @@ type DefaultMention struct {
 	roleId RoleID `json:"-"`
 }
 
-// Creates new DefaultUserMention type with only UserID
+// DefaultUserMention creates a new DefaultMention type with only UserID
 func DefaultUserMention (userId UserID) DefaultMention {
 	return DefaultMention{userId: userId}
 }
 
-// Creates new DefaultRoleMention type with only RoleID
+// DefaultRoleMention creates a new DefaultMention type with only RoleID
 func DefaultRoleMention(roleId RoleID) DefaultMention {
 	return DefaultMention{roleId: roleId}
 }


### PR DESCRIPTION
This PR adds the following fields to ChannelSelectComponent, MentionableSelectComponent and RoleSelectComponent,

- `SelectedRoles` for `RoleSelectComponent`.
- `SelectedChannels` for `ChannelSelectComponent`.
- `SelectedMentions` for `MentionableSelectComponent`.
- `SelectedUsers` for `UserSelectComponent`.

All the fields will take in the slice of ID's of their kind and populates the SelectComponent beforehand.

> [!NOTE]
> `SelectedMentions` will take in the slice of `interface{}` and later type-asserted to respective UserID / RoleID.
> If wanted to change this implementation, please lmk.