### PR TITLE
Support GIF banner URLs

### DIFF
--- a/discord/guild.go
+++ b/discord/guild.go
@@ -142,15 +142,16 @@ func (g Guild) IconURLWithType(t ImageType) string {
 }
 
 // BannerURL returns the URL to the banner, which is the image on top of the
-// channels list. This will always return a link to a PNG file.
+// channels list. Auto detects a suitable image type. An empty string is
+// returned if the guild has no banner.
 func (g Guild) BannerURL() string {
-	return g.BannerURLWithType(PNGImage)
+	return g.BannerURLWithType(AutoImage)
 }
 
 // BannerURLWithType returns the URL to the banner, which is the image on top
 // of the channels list using the passed image type.
 //
-// Supported ImageTypes: PNG, JPEG, WebP
+// Supported ImageTypes: PNG, JPEG, WebP, GIF
 func (g Guild) BannerURLWithType(t ImageType) string {
 	if g.Banner == "" {
 		return ""


### PR DESCRIPTION
Currently, `Guild.BannerURL()` returns the banner as a `PNG` URL no matter the circumstances. I'm not sure if banners were PNG-only when they were first added to Discord, but they can be animated now and we can use the same logic to determine if it's animated or not as we do with user avatars and guild icons.